### PR TITLE
feat: add peripheralDevice methods to list and get known rundowns

### DIFF
--- a/meteor/lib/api/peripheralDevice.ts
+++ b/meteor/lib/api/peripheralDevice.ts
@@ -117,6 +117,8 @@ export enum methods {
 	'mosRoReadyToAir' 	= 'peripheralDevice.mos.roReadyToAir',
 	'mosRoFullStory' 	= 'peripheralDevice.mos.roFullStory',
 
+	'dataRundownList'	= 'peripheralDevice.rundown.rundownList',
+	'dataRundownGet'	= 'peripheralDevice.rundown.rundownGet',
 	'dataRundownDelete'	= 'peripheralDevice.rundown.rundownDelete',
 	'dataRundownCreate'	= 'peripheralDevice.rundown.rundownCreate',
 	'dataRundownUpdate'	= 'peripheralDevice.rundown.rundownUpdate',

--- a/meteor/server/api/ingest/api.ts
+++ b/meteor/server/api/ingest/api.ts
@@ -7,6 +7,12 @@ import { RundownInput } from './rundownInput'
 
 let methods: Methods = {}
 
+methods[PeripheralDeviceAPI.methods.dataRundownList] = (deviceId: string, deviceToken: string) => {
+	return RundownInput.dataRundownList(this, deviceId, deviceToken)
+}
+methods[PeripheralDeviceAPI.methods.dataRundownGet] = (deviceId: string, deviceToken: string, rundownExternalId: string) => {
+	return RundownInput.dataRundownGet(this, deviceId, deviceToken, rundownExternalId)
+}
 methods[PeripheralDeviceAPI.methods.dataRundownDelete] = (deviceId: string, deviceToken: string, rundownExternalId: string) => {
 	return RundownInput.dataRundownDelete(this, deviceId, deviceToken, rundownExternalId)
 }


### PR DESCRIPTION
`peripheralDevice.rundown.rundownList` will return an array of the rundown externalIds.

`peripheralDevice.rundown.rundownGet` will get the fill IngestRundown of the rundown/