### PR TITLE
fix/hack: Add property Piece.definitelyEnded

### DIFF
--- a/meteor/lib/collections/Pieces.ts
+++ b/meteor/lib/collections/Pieces.ts
@@ -69,6 +69,8 @@ export interface Piece extends PieceGeneric, IBlueprintPieceDB {
 	userDuration?: Pick<Timeline.TimelineEnable, 'duration' | 'end'>
 	/** This is set when the piece is infinite, to deduplicate the contents on the timeline, while allowing out of order */
 	infiniteMode?: PieceLifespan
+	/** [timestamp) After this time, the piece has definitely ended and its content can be omitted from the timeline */
+	definitelyEnded?: number
 	/** This is a backup of the original infiniteMode of the piece, so that the normal field can be modified during playback and restored afterwards */
 	originalInfiniteMode?: PieceLifespan
 	// /** This is the id of the original segment of an infinite piece chain. If it matches the id of itself then it is the first in the chain */

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -8,8 +8,11 @@ import { Part } from '../../../lib/collections/Parts'
 import { syncFunctionIgnore, syncFunction } from '../../codeControl'
 import { Piece, Pieces } from '../../../lib/collections/Pieces'
 import { getOrderedPiece, PieceResolved } from './pieces'
-import { asyncCollectionUpdate, waitForPromiseAll, asyncCollectionRemove, asyncCollectionInsert, normalizeArray, toc, makePromise, waitForPromise } from '../../../lib/lib'
+import { asyncCollectionUpdate, waitForPromiseAll, asyncCollectionRemove, asyncCollectionInsert, normalizeArray, toc, makePromise, waitForPromise, getCurrentTime } from '../../../lib/lib'
 import { logger } from '../../../lib/logging'
+
+/** When we crop a piece, set the piece as "it has definitely ended" this far into the future. */
+const DEFINITELY_ENDED_FUTURE_DURATION = 10 * 1000
 
 export const updateSourceLayerInfinitesAfterPart: (rundown: Rundown, previousPart?: Part, runUntilEnd?: boolean) => void
 = syncFunctionIgnore(updateSourceLayerInfinitesAfterPartInner)
@@ -253,6 +256,7 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 	for (const piece of pieces) {
 		ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
 			userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
+			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION,
 			infiniteMode: PieceLifespan.Normal,
 			originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
 		}}))

--- a/meteor/server/api/playout/infinites.ts
+++ b/meteor/server/api/playout/infinites.ts
@@ -256,7 +256,7 @@ export const cropInfinitesOnLayer = syncFunction(function cropInfinitesOnLayer (
 	for (const piece of pieces) {
 		ps.push(asyncCollectionUpdate(Pieces, piece._id, { $set: {
 			userDuration: { end: `#${getPieceGroupId(newPiece)}.start + ${newPiece.adlibPreroll || 0}` },
-			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION,
+			definitelyEnded: getCurrentTime() + DEFINITELY_ENDED_FUTURE_DURATION + (newPiece.adlibPreroll || 0),
 			infiniteMode: PieceLifespan.Normal,
 			originalInfiniteMode: piece.originalInfiniteMode !== undefined ? piece.originalInfiniteMode : piece.infiniteMode
 		}}))

--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -700,6 +700,7 @@ function transformPartIntoTimeline (
 		if (piece.isTransition && (!allowTransition || isHold)) {
 			return
 		}
+		if (piece.definitelyEnded && piece.definitelyEnded < getCurrentTime()) return
 
 		if (piece.infiniteId && piece.infiniteId !== piece._id) {
 			piece._id = piece.infiniteId


### PR DESCRIPTION
...to be used to easilly filter out old and cropped pieces.

This is intended to reduce the number of timeline-objects that are generated when adlibbing a lot.

_Note: I do not have the full overview of the implications of this hack. I've tested it locally and it seems to work, but I need some more sets of eyes on this before we dare deploy it to prod._

Basically, how it works:
* When we crop an infinite-piece, due to an exclusivity-group, I set the new `definitelyEnded`-propery to a time 10s into the future.
* When that time has passed, we'll filter out the content of the piece right away, so it won't render any timeline-objects
* The 10s allows for any transition to finish