### PR TITLE
Feat/snapshot on all evaluations

### DIFF
--- a/meteor/client/ui/AfterBroadcastForm.tsx
+++ b/meteor/client/ui/AfterBroadcastForm.tsx
@@ -50,17 +50,13 @@ export const AfterBroadcastForm = translate()(class AfterBroadcastForm extends R
 			})
 		}
 
-		if (answers.q0 !== 'nothing') {
-			doUserAction(t, e, UserActionAPI.methods.storeRundownSnapshot, [this.props.rundown._id, 'Evaluation form'], (err, response) => {
-				if (!err && response) {
-					saveEvaluation(response.result)
-				} else {
-					saveEvaluation()
-				}
-			})
-		} else {
-			saveEvaluation()
-		}
+		doUserAction(t, e, UserActionAPI.methods.storeRundownSnapshot, [this.props.rundown._id, 'Evaluation form'], (err, response) => {
+			if (!err && response) {
+				saveEvaluation(response.result)
+			} else {
+				saveEvaluation()
+			}
+		})
 	}
 	onUpdateValue = (edit: any, newValue: any) => {
 		let attr = edit.props.attribute

--- a/meteor/client/ui/AfterBroadcastForm.tsx
+++ b/meteor/client/ui/AfterBroadcastForm.tsx
@@ -50,13 +50,17 @@ export const AfterBroadcastForm = translate()(class AfterBroadcastForm extends R
 			})
 		}
 
-		doUserAction(t, e, UserActionAPI.methods.storeRundownSnapshot, [this.props.rundown._id, 'Evaluation form'], (err, response) => {
-			if (!err && response) {
-				saveEvaluation(response.result)
-			} else {
-				saveEvaluation()
-			}
-		})
+		if (answers.q0 !== 'nothing' || answers.q1.trim() !== '') {
+			doUserAction(t, e, UserActionAPI.methods.storeRundownSnapshot, [this.props.rundown._id, 'Evaluation form'], (err, response) => {
+				if (!err && response) {
+					saveEvaluation(response.result)
+				} else {
+					saveEvaluation()
+				}
+			})
+		} else {
+			saveEvaluation()
+		}
 	}
 	onUpdateValue = (edit: any, newValue: any) => {
 		let attr = edit.props.attribute


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature change on when we store snapshots from Evaluations submitted by the user.


* **What is the current behavior?** (You can also link to an open issue here)
We only store evaluations if the user selects level "minor" or "major".


* **What is the new behavior (if this is a feature change)?**
We should also store snapshots at level "nothing" IF the user has made a comments. 

The motivation is that the user can notice something in the system and make a comment of it, something worth investigating, even at level "nothing". 


* **Other information**:
Untested
The first commit gets nulled out by the second one. After a squash you'll end up with just the second commit (as shown under "Files changed"). I didn't bother to squash and force push.

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] The functionality has been tested by the PR author
