### PR TITLE
Fix/settings fields behavior

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -101,10 +101,14 @@ export class EditAttributeBase extends React.Component<IEditAttributeBaseProps, 
 		this.handleUpdateButDontSave(newValue)
 		this.updateValue(newValue)
 	}
-	handleUpdateButDontSave (newValue) {
+	handleUpdateEditing (newValue) {
+		this.handleUpdateButDontSave(newValue, true)
+		this.updateValue(newValue)
+	}
+	handleUpdateButDontSave (newValue, editing=false) {
 		this.setState({
 			value: newValue,
-			editing: false
+			editing
 		})
 	}
 	handleDiscard () {
@@ -275,7 +279,7 @@ const EditAttributeInt = wrapEditAttribute(class extends EditAttributeBase {
 	handleChange (event) {
 		// this.handleEdit(this.getValue(event))
 		let v = this.getValue(event)
-		_.isNaN(v) ? this.handleUpdateButDontSave(v) : this.handleUpdate(v)
+		_.isNaN(v) ? this.handleUpdateButDontSave(v, true) : this.handleUpdateEditing(v)
 	}
 	handleBlur (event) {
 		let v = this.getValue(event)
@@ -283,7 +287,7 @@ const EditAttributeInt = wrapEditAttribute(class extends EditAttributeBase {
 	}
 	getEditAttributeNumber () {
 		let val = this.getEditAttribute()
-		if (_.isNaN(val)) val = 'NaN'
+		if (_.isNaN(val)) val = ''
 		return val
 	}
 	render () {
@@ -312,7 +316,7 @@ const EditAttributeFloat = wrapEditAttribute(class extends EditAttributeBase {
 	handleChange (event) {
 		// this.handleEdit(this.getValue(event))
 		let v = this.getValue(event)
-		_.isNaN(v) ? this.handleUpdateButDontSave(v) : this.handleUpdate(v)
+		_.isNaN(v) ? this.handleUpdateButDontSave(v, true) : this.handleUpdateEditing(v)
 	}
 	handleBlur (event) {
 		let v = this.getValue(event)
@@ -320,7 +324,7 @@ const EditAttributeFloat = wrapEditAttribute(class extends EditAttributeBase {
 	}
 	getEditAttributeNumber () {
 		let val = this.getEditAttribute()
-		if (_.isNaN(val)) val = 'NaN'
+		if (_.isNaN(val)) val = ''
 		return val
 	}
 	render () {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Fixes numeric input fields being hard to type into and other inputs flashing with their previous value when losing focus

* **What is the current behavior?** The cursor is jumping to the end of the number; it is impossible to fully clear the input; typing fast is impeded
When finishing editing a text field (losing focus), it's showing its previous value for a moment

* **What is the new behavior (if this is a feature change)?**
Above issues are resolved

