### PR TITLE
Feat/settings improvements (tables)

### DIFF
--- a/meteor/client/styles/settings.scss
+++ b/meteor/client/styles/settings.scss
@@ -93,6 +93,33 @@
 				}
 			}
 		}
+
+		.expando-details > td {
+			max-width: 0;
+		}
+	}
+
+	.settings-studio-sticky-scroller {
+		overflow: auto;
+		max-height: 80vh;
+		margin-bottom: 8px;
+
+		> table {
+
+			> tbody > tr > td {
+				text-align: center;
+				padding-right: 3px;
+			}
+	
+			> thead > tr > th {
+				position: sticky;
+				position: -webkit-sticky;
+				top: 0;
+				background: #fff;
+				z-index: 20;
+				padding-right: 3px;
+			}
+		}
 	}
 
 	.settings-studio-device-dropdown {

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -203,31 +203,32 @@ export class ConfigManifestTable<TCol extends TransformedCollection<TObj2, TObj>
 
 		return (
 			<div>
-				<table className='table'>
-					<thead>
-						<tr>
-							{ _.map(configEntry.columns, col => <th key={col.id}><span title={col.description}>{ col.name} </span></th>) }
-							<th>&nbsp;</th>
-						</tr>
-					</thead>
-					<tbody>
-					{
-						_.map(vals, (val, i) => <tr key={i}>
-							{ _.map(configEntry.columns, col => <td key={col.id}>{
-								getEditAttribute(this.props.collection, this.props.object, col, `${baseAttribute}.${i}.${col.id}`)
-							}</td>) }
-							<td>
-								<button className={ClassNames('btn btn-danger', {
-									'btn-tight': this.props.subPanel
-								})} onClick={() => this.removeRow(val._id, baseAttribute)}>
-									<FontAwesomeIcon icon={faTrash} />
-								</button>
-							</td>
-						</tr>)
-					}
-					</tbody>
-				</table>
-
+				<div className='settings-studio-sticky-scroller'>
+					<table className='table'>
+						<thead>
+							<tr>
+								{ _.map(configEntry.columns, col => <th key={col.id}><span title={col.description}>{ col.name} </span></th>) }
+								<th>&nbsp;</th>
+							</tr>
+						</thead>
+						<tbody>
+						{
+							_.map(vals, (val, i) => <tr key={i}>
+								{ _.map(configEntry.columns, col => <td key={col.id}>{
+									getEditAttribute(this.props.collection, this.props.object, col, `${baseAttribute}.${i}.${col.id}`)
+								}</td>) }
+								<td>
+									<button className={ClassNames('btn btn-danger', {
+										'btn-tight': this.props.subPanel
+									})} onClick={() => this.removeRow(val._id, baseAttribute)}>
+										<FontAwesomeIcon icon={faTrash} />
+									</button>
+								</td>
+							</tr>)
+						}
+						</tbody>
+					</table>
+				</div>
 				<button className={ClassNames('btn btn-primary', {
 					'btn-tight': this.props.subPanel
 				})} onClick={() => this.addRow(configEntry, baseAttribute)}>
@@ -491,11 +492,8 @@ export class ConfigManifestSettings<TCol extends TransformedCollection<TObj2, TO
 
 	render () {
 		const { t } = this.props
-		const divStyle: React.CSSProperties = {
-			overflowX: 'scroll'
-		}
 		return (
-			<div style={divStyle}>
+			<div>
 				<ModalDialog title={t('Add config item')} acceptText={t('Add')}
 					secondaryText={t('Cancel')} show={this.state.showAddItem}
 					onAccept={(e) => this.handleConfirmAddItemAccept(e)}

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -42,7 +42,7 @@ function getEditAttribute<TObj, TObj2> (collection: TransformedCollection<TObj2,
 				obj={object}
 				type='int'
 				collection={collection}
-				className='input text-input input-l' />
+				className='input text-input input-m' />
 		case ConfigManifestEntryType.BOOLEAN:
 			return <EditAttribute
 				modifiedClassName='bghl'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 

- Makes the headers in big tables (e.g. GFX Templates) sticky.
- Makes those tables fit screen height and have their scrollbars and buttons visible for easier usage.
- Shortens numeric inputs to make the tables more compact.
- Adds optional sorting to tables by string and numeric columns.

