### PR TITLE
Feat/Shelf with inactive rundown

### DIFF
--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -144,7 +144,8 @@ class App extends React.Component<InjectedI18nProps, IAppState> {
 							{/* <Route exact path='/' component={Dashboard} /> */}
 							<Route exact path='/' component={RundownList} />
 							<Route path='/rundowns' component={RundownList} />
-							<Route path='/rundown/:rundownId' component={RundownView} />
+							<Route path='/rundown/:rundownId' component={RundownView} exact/>
+							<Route path='/rundown/:rundownId/shelf' exact render={(props) => <RundownView {...props} onlyShelf={true}/>}/>
 							<Route path='/activeRundown/:studioId' component={ActiveRundownView} />
 							<Route path='/prompter/:studioId' component={PrompterView} />
 							<Route path='/countdowns/:studioId/presenter' component={ClockView} />

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1091,6 +1091,13 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 	const params = queryStringParse(location.search)
 
+	let onlyShelf = false
+	if (props.onlyShelf) {
+		onlyShelf = props.onlyShelf
+	} else if (params['onlyShelf']) {
+		onlyShelf = params['onlyShelf'] === 'true'
+	}
+
 	// let rundownDurations = calculateDurations(rundown, parts)
 	return {
 		rundownId: rundownId,
@@ -1118,7 +1125,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			type: PeripheralDeviceAPI.DeviceType.PLAYOUT,
 			subType: TSR_DeviceType.CASPARCG
 		}).fetch()) || undefined,
-		rundownLayoutId: String(params['layout'])
+		rundownLayoutId: String(params['layout']),
+		onlyShelf: onlyShelf
 	}
 })(class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		private readonly LIVELINE_HISTORY_SIZE = 100

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -1091,13 +1091,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 
 	const params = queryStringParse(location.search)
 
-	let onlyShelf = false
-	if (props.onlyShelf) {
-		onlyShelf = props.onlyShelf
-	} else if (params['onlyShelf']) {
-		onlyShelf = params['onlyShelf'] === 'true'
-	}
-
 	// let rundownDurations = calculateDurations(rundown, parts)
 	return {
 		rundownId: rundownId,
@@ -1125,8 +1118,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			type: PeripheralDeviceAPI.DeviceType.PLAYOUT,
 			subType: TSR_DeviceType.CASPARCG
 		}).fetch()) || undefined,
-		rundownLayoutId: String(params['layout']),
-		onlyShelf: onlyShelf
+		rundownLayoutId: String(params['layout'])
 	}
 })(class RundownView extends MeteorReactComponent<Translated<IProps & ITrackedProps>, IState> {
 		private readonly LIVELINE_HISTORY_SIZE = 100


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR enables viewing the shelf of a chosen rundown even if it's inactive.

* **What is the new behavior (if this is a feature change)?**
The shelf can be viewed under `/rundown/:rundownId/shelf` path.
The `layout` query string parameter works with the new path as before.
