### PR TITLE
Feat/rundown list links

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -8,7 +8,7 @@ import { Mongo } from 'meteor/mongo'
 
 import { MultiSelect, MultiSelectEvent } from './multiSelect'
 import { ColorPickerEvent, ColorPicker } from './colorPicker'
-import { IconPicker } from './iconPicker'
+import { IconPicker, IconPickerEvent } from './iconPicker'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType
@@ -588,7 +588,7 @@ const EditAttributeIconPicker = wrapEditAttribute(class extends EditAttributeBas
 
 		this.handleChange = this.handleChange.bind(this)
 	}
-	handleChange (event: ColorPickerEvent) {
+	handleChange (event: IconPickerEvent) {
 		this.handleUpdate(event.selectedValue)
 	}
 	render () {

--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -8,11 +8,12 @@ import { Mongo } from 'meteor/mongo'
 
 import { MultiSelect, MultiSelectEvent } from './multiSelect'
 import { ColorPickerEvent, ColorPicker } from './colorPicker'
+import { IconPicker } from './iconPicker'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType
 }
-export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect' | 'colorpicker'
+export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect' | 'colorpicker' | 'iconpicker'
 export class EditAttribute extends React.Component<IEditAttribute> {
 	render () {
 
@@ -51,6 +52,10 @@ export class EditAttribute extends React.Component<IEditAttribute> {
 		} else if (this.props.type === 'colorpicker') {
 			return (
 				<EditAttributeColorPicker {...this.props} />
+			)
+		} else if (this.props.type === 'iconpicker') {
+			return (
+				<EditAttributeIconPicker {...this.props} />
 			)
 		}
 
@@ -574,6 +579,27 @@ const EditAttributeColorPicker = wrapEditAttribute(class extends EditAttributeBa
 				placeholder={this.props.label}
 				onChange={this.handleChange}>
 			</ColorPicker>
+		)
+	}
+})
+const EditAttributeIconPicker = wrapEditAttribute(class extends EditAttributeBase {
+	constructor (props) {
+		super(props)
+
+		this.handleChange = this.handleChange.bind(this)
+	}
+	handleChange (event: ColorPickerEvent) {
+		this.handleUpdate(event.selectedValue)
+	}
+	render () {
+		return (
+			<IconPicker
+				className={this.props.className}
+				availableOptions={this.props.options}
+				value={this.getAttribute()}
+				placeholder={this.props.label}
+				onChange={this.handleChange}>
+			</IconPicker>
 		)
 	}
 })

--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -7,11 +7,12 @@ import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import { Mongo } from 'meteor/mongo'
 
 import { MultiSelect, MultiSelectEvent } from './multiSelect'
+import { ColorPickerEvent, ColorPicker } from './colorPicker'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType
 }
-export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect'
+export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect' | 'colorpicker'
 export class EditAttribute extends React.Component<IEditAttribute> {
 	render () {
 
@@ -46,6 +47,10 @@ export class EditAttribute extends React.Component<IEditAttribute> {
 		} else if (this.props.type === 'multiselect') {
 			return (
 				<EditAttributeMultiSelect {...this.props} />
+			)
+		} else if (this.props.type === 'colorpicker') {
+			return (
+				<EditAttributeColorPicker {...this.props} />
 			)
 		}
 
@@ -548,6 +553,27 @@ const EditAttributeMultiSelect = wrapEditAttribute(class extends EditAttributeBa
 				placeholder={this.props.label}
 				onChange={this.handleChange}>
 			</MultiSelect>
+		)
+	}
+})
+const EditAttributeColorPicker = wrapEditAttribute(class extends EditAttributeBase {
+	constructor (props) {
+		super(props)
+
+		this.handleChange = this.handleChange.bind(this)
+	}
+	handleChange (event: ColorPickerEvent) {
+		this.handleUpdate(event.selectedValue)
+	}
+	render () {
+		return (
+			<ColorPicker
+				className={this.props.className}
+				availableOptions={this.props.options}
+				value={this.getAttribute()}
+				placeholder={this.props.label}
+				onChange={this.handleChange}>
+			</ColorPicker>
 		)
 	}
 })

--- a/meteor/client/lib/colorPicker.tsx
+++ b/meteor/client/lib/colorPicker.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import * as ClassNames from 'classnames'
+
+import * as faChevronUp from '@fortawesome/fontawesome-free-solid/faChevronUp'
+import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+export interface ColorPickerEvent {
+	selectedValue: string
+}
+
+export const defaultColorPickerPalette = [
+	'#ffffff', '#23ad94', '#14c942', '#1769ff', '#8e44ad', '#1c177a', '#000000', '#f0d718', '#e67e22', '#e82c2c', '#ecf0f1', '#95a5a6'
+]
+
+interface IProps {
+	availableOptions: Array<string>
+	placeholder?: string
+	className?: string
+	value?: string
+	onChange?: (event: ColorPickerEvent) => void
+}
+
+interface IState {
+	selectedValue: string
+	expanded: boolean
+}
+
+export class ColorPicker extends React.Component<IProps, IState> {
+	constructor (props: IProps) {
+		super(props)
+
+		this.state = {
+			selectedValue: '',
+			expanded: false
+		}
+	}
+
+	componentDidMount () {
+		this.refreshChecked()
+	}
+
+	componentDidUpdate (prevProps: IProps) {
+		if (this.props.value !== prevProps.value) {
+			this.refreshChecked()
+		}
+	}
+
+	refreshChecked () {
+		if (this.props.value) {
+			this.setState({
+				selectedValue: this.props.value
+			})
+		} else {
+			this.setState({
+				selectedValue: ''
+			})
+		}
+	}
+
+	handleChange = (value) => {
+		this.setState({
+			selectedValue: value
+		})
+
+		if (this.props.onChange && typeof this.props.onChange === 'function') {
+			this.props.onChange({ selectedValue: value })
+		}
+	}
+
+	toggleExpco = () => {
+		this.setState({
+			expanded: !this.state.expanded
+		})
+	}
+
+	render () {
+		return (
+			<div className={ClassNames('expco focusable subtle colorpicker', {
+				'expco-expanded': this.state.expanded
+			}, this.props.className)}>
+				<div className={ClassNames('expco-title focusable-main')} onClick={this.toggleExpco}>
+					<div className='color-preview' style={{ backgroundColor: this.state.selectedValue }}></div>
+				</div>
+				<a className='action-btn right expco-expand subtle' onClick={this.toggleExpco}>
+					<FontAwesomeIcon icon={faChevronUp} />
+				</a>
+				<div className='expco-body bd'>
+					{
+						_.values(_.mapObject(this.props.availableOptions, (value, key) => {
+							return (
+								<div className='expco-item' key={key}>
+									<label className='action-btn' onClick={() => this.handleChange(value)}>
+										<div className='color-preview' style={{ backgroundColor: value }}></div>
+									</label>
+								</div>
+							)
+						}))
+					}
+				</div>
+			</div>
+		)
+	}
+}

--- a/meteor/client/lib/colorPicker.tsx
+++ b/meteor/client/lib/colorPicker.tsx
@@ -66,6 +66,7 @@ export class ColorPicker extends React.Component<IProps, IState> {
 		if (this.props.onChange && typeof this.props.onChange === 'function') {
 			this.props.onChange({ selectedValue: value })
 		}
+		this.toggleExpco()
 	}
 
 	toggleExpco = () => {

--- a/meteor/client/lib/iconPicker.tsx
+++ b/meteor/client/lib/iconPicker.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import * as ClassNames from 'classnames'
+
+import * as faChevronUp from '@fortawesome/fontawesome-free-solid/faChevronUp'
+import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+import pack, { IconPack, IconDefinition } from '@fortawesome/fontawesome-free-solid'
+import { translate } from 'react-i18next'
+import { Translated } from './ReactMeteorData/ReactMeteorData'
+
+export interface IconPickerEvent {
+	selectedValue: string
+}
+
+interface IProps {
+	availableOptions: Array<string>
+	placeholder?: string
+	className?: string
+	value?: string
+	onChange?: (event: IconPickerEvent) => void
+}
+
+interface IState {
+	selectedValue: string
+	expanded: boolean
+	iconPack: IconPack
+	searchText: string
+}
+
+export const IconPicker = translate()(class IconPicker extends React.Component<Translated<IProps>, IState> {
+	constructor (props: Translated<IProps>) {
+		super(props)
+
+		delete pack['faFontAwesomeLogoFull']
+
+		this.state = {
+			selectedValue: '',
+			expanded: false,
+			iconPack: pack,
+			searchText: ''
+		}
+	}
+
+	componentDidMount () {
+		this.refreshChecked()
+	}
+
+	componentDidUpdate (prevProps: IProps) {
+		if (this.props.value !== prevProps.value) {
+			this.refreshChecked()
+		}
+	}
+
+	refreshChecked () {
+		if (this.props.value) {
+			this.setState({
+				selectedValue: this.props.value
+			})
+		} else {
+			this.setState({
+				selectedValue: ''
+			})
+		}
+	}
+
+	handleChange = (value) => {
+		this.setState({
+			selectedValue: value
+		})
+
+		if (this.props.onChange && typeof this.props.onChange === 'function') {
+			this.props.onChange({ selectedValue: value })
+		}
+		this.toggleExpco()
+	}
+
+	handleSearchChange = (event) => {
+		this.setState({
+			searchText: event.target.value
+		})
+	}
+
+	toggleExpco = () => {
+		this.setState({
+			expanded: !this.state.expanded
+		})
+	}
+
+	getFilteredIcons () {
+		return this.state.searchText ? _.pick(this.state.iconPack, (value: IconDefinition) => {
+			return value.iconName.includes(this.state.searchText)
+		}) : this.state.iconPack
+	}
+
+	render () {
+		const { t } = this.props
+		return (
+			<div className={ClassNames('expco focusable subtle iconpicker', {
+				'expco-expanded': this.state.expanded
+			}, this.props.className)}>
+				<div className={ClassNames('expco-title focusable-main')} onClick={this.toggleExpco}>
+					{this.state.selectedValue && <FontAwesomeIcon icon={this.state.selectedValue} />}
+				</div>
+				<a className='action-btn right expco-expand subtle' onClick={this.toggleExpco}>
+					<FontAwesomeIcon icon={faChevronUp} />
+				</a>
+				<div className='expco-body bd'>
+					<input type='text' className='search-input' placeholder={t('Search...')} onChange={this.handleSearchChange}></input>
+					<div className='expco-list'>
+						{!this.state.searchText &&
+							<div className='expco-item'>
+								<label className='action-btn' onClick={() => this.handleChange('')}>&nbsp;</label>
+							</div>
+						}
+						{
+							_.values(_.mapObject(this.getFilteredIcons(), (value, key) => {
+								return (
+									<div className='expco-item' key={key}>
+										<label className='action-btn' title={value.iconName} onClick={() => this.handleChange(value)}>
+											<FontAwesomeIcon icon={value.iconName} />
+										</label>
+									</div>
+								)
+							}))
+						}
+					</div>
+				</div>
+			</div>
+		)
+	}
+})

--- a/meteor/client/lib/splitDropdown.tsx
+++ b/meteor/client/lib/splitDropdown.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import * as _ from 'underscore'
+import * as ClassNames from 'classnames'
+
+import * as faChevronUp from '@fortawesome/fontawesome-free-solid/faChevronUp'
+import * as FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+interface IProps {
+	elements: Array<React.ReactNode>
+	selectedKey: string
+	className?: string
+}
+
+interface IState {
+	expanded: boolean
+}
+
+export class SplitDropdown extends React.Component<IProps, IState> {
+	constructor (props: IProps) {
+		super(props)
+
+		this.state = {
+			expanded: false
+		}
+	}
+
+	toggleExpco = () => {
+		this.setState({
+			expanded: !this.state.expanded
+		})
+	}
+
+	getSelected () {
+		return (
+			this.props.elements.find(element => (element as React.ReactElement<{}>).key === this.props.selectedKey) ||
+			<div className='expco-item'></div>
+		)
+	}
+
+	render () {
+		return (
+			<div className={ClassNames('expco focusable subtle split-dropdown', {
+				'expco-expanded': this.state.expanded
+			}, this.props.className)}>
+				<div className={ClassNames('expco-title focusable-main')}>{this.getSelected()}</div>
+				<a className='action-btn right expco-expand subtle' onClick={this.toggleExpco}>
+					<FontAwesomeIcon icon={faChevronUp} />
+				</a>
+				<div className='expco-body bd'>
+					{this.props.elements}
+				</div>
+			</div>
+		)
+	}
+}

--- a/meteor/client/styles/colorPicker.scss
+++ b/meteor/client/styles/colorPicker.scss
@@ -1,0 +1,57 @@
+.expco.colorpicker {
+	position: relative;
+	padding-top: 0;
+	padding-bottom: 0;
+	padding-left: 8px;
+
+	&.expco-expanded  {
+		z-index: 2;
+	}
+
+	.expco-expand {
+		cursor: pointer;
+	}
+
+	.expco-title {
+		white-space: nowrap;
+		margin-right: 24px;
+		width: 100%;
+		padding: 7px 0px;
+		overflow: hidden;
+		vertical-align: middle;
+	}
+
+	.expco-body {
+		position: absolute;
+		left: -1px;
+		width: 210px;
+		top: 100%;
+		max-height: 16em;
+		background: #fff;
+		overflow-y: auto;
+		border: 1px solid #bbb;
+		padding: 4px;
+	}
+
+	.expco-item {
+		display: inline-flex;
+		white-space: pre;
+		margin: 4px;
+
+		&.action-btn {
+			padding: 0px;
+			margin: 0px;
+			width: 100%;
+			color: #252627;
+			font-weight: 300;
+		}
+	}
+
+	.color-preview {
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		border: 1px solid #bbb;
+	}
+
+}

--- a/meteor/client/styles/iconPicker.scss
+++ b/meteor/client/styles/iconPicker.scss
@@ -1,4 +1,4 @@
-.expco.colorpicker {
+.expco.iconpicker {
 	position: relative;
 	padding-top: 0;
 	padding-bottom: 0;
@@ -16,7 +16,7 @@
 		white-space: nowrap;
 		margin-right: 24px;
 		width: 100%;
-		padding: 12px 0px;
+		padding: 1px 0px;
 		overflow: hidden;
 		vertical-align: middle;
 	}
@@ -24,34 +24,37 @@
 	.expco-body {
 		position: absolute;
 		left: -1px;
-		width: 210px;
+		width: 320px;
 		top: 100%;
-		max-height: 16em;
 		background: #fff;
-		overflow-y: auto;
 		border: 1px solid #bbb;
-		padding: 4px;
+		padding: 0px;
 	}
 
 	.expco-item {
 		display: inline-flex;
 		white-space: pre;
 		margin: 4px;
+		width: 24px;
+		text-align: center;
 
-		&.action-btn {
+		.action-btn {
 			padding: 0px;
 			margin: 0px;
 			width: 100%;
-			color: #252627;
-			font-weight: 300;
 		}
 	}
 
-	.color-preview {
-		width: 16px;
-		height: 16px;
-		border-radius: 50%;
-		border: 1px solid #bbb;
+	.expco-list {
+		overflow-y: auto;
+		max-height: 16em;
+		padding: 4px;
+	}
+
+	.search-input {
+		width: calc(100% - 8px);
+		padding: 5px;
+		margin: 4px;
 	}
 
 }

--- a/meteor/client/styles/splitDropdown.scss
+++ b/meteor/client/styles/splitDropdown.scss
@@ -59,12 +59,19 @@
 		border-bottom: 1px solid #ddd;
 	}
 
-	.layout-indicator {
-		width: 10px;
-		height: 10px;
+	.layout-icon {
+		width: 16px;
+		height: 16px;
+		text-align: center;
 		border-radius: 50%;
 		display: inline-block;
-		margin: 0 5px 3px 0;
+		margin: 0 6px 3px 0;
+		line-height: 1em;
 		vertical-align: middle;
+
+		&.small {
+			font-size: 0.6em;
+			line-height: 1.8em;
+		}
 	}
 }

--- a/meteor/client/styles/splitDropdown.scss
+++ b/meteor/client/styles/splitDropdown.scss
@@ -1,0 +1,70 @@
+.expco.split-dropdown {
+	position: relative;
+	padding-top: 0;
+	padding-bottom: 0;
+	&.expco-expanded  {
+		z-index: 2;
+	}
+
+	.expco-expand {
+		cursor: pointer;
+	}
+
+	.expco-title {
+		white-space: nowrap;
+		margin-right: 24px;
+		cursor: auto;
+		width: auto;
+		border-right: 1px solid #ccc;
+		border-radius: 0px;
+		padding: 0px;
+	}
+
+	.expco-body {
+		position: absolute;
+		right: -1px;
+		top: 100%;
+		max-height: 16em;
+		background: #fff;
+		overflow-y: auto;
+		border: 1px solid #bbb;
+		padding: 2px 0 4px 0;
+	}
+
+	.expco-item {
+		display: inline-block;
+		white-space: pre;
+
+		&.action-btn {
+			padding: 5px 10px;
+			margin: 0px;
+			width: 100%;
+			color: #252627;
+			font-weight: 300;
+		}
+	}
+	
+
+	.expco-header {
+		text-transform: uppercase;
+		font-size: .8em;
+		font-weight: bold;
+		padding: 12px 10px 4px 10px;
+		color: #999;
+		white-space: pre;
+	}
+
+	.expco-separator {
+		margin: 4px 0px;
+		border-bottom: 1px solid #ddd;
+	}
+
+	.layout-indicator {
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		display: inline-block;
+		margin: 0 5px 3px 0;
+		vertical-align: middle;
+	}
+}

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -28,20 +28,29 @@ import { ShowStyleVariants } from '../../lib/collections/ShowStyleVariants'
 import { PubSub } from '../../lib/api/pubsub'
 import { ReactNotification } from '../lib/notifications/ReactNotification'
 import { Spinner } from '../lib/Spinner'
+import { SplitDropdown } from '../lib/splitDropdown'
+import { RundownLayoutBase, RundownLayouts } from '../../lib/collections/RundownLayouts'
+import { UIStateStorage } from '../lib/UIStateStorage'
 
 const PackageInfo = require('../../package.json')
 
 interface IRundownListItemProps {
 	key: string,
 	rundown: RundownUI
+	rundownLayouts: Array<RundownLayoutBase>
 }
 
-interface IRundownListItemStats {
+interface IRundownListItemState {
+	selectedView: string
 }
 
-export class RundownListItem extends React.Component<Translated<IRundownListItemProps>, IRundownListItemStats> {
+export class RundownListItem extends React.Component<Translated<IRundownListItemProps>, IRundownListItemState> {
 	constructor (props) {
 		super(props)
+
+		this.state = {
+			selectedView: UIStateStorage.getItemString(`rundownList.${this.props.rundown.showStyleVariantId}`, 'defaultView', 'default')
+		}
 	}
 
 	getRundownLink (rundownId) {
@@ -55,6 +64,14 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 	getshowStyleBaseLink (showStyleBaseId) {
 		// double encoding so that "/" are handled correctly
 		return '/settings/showStyleBase/' + encodeURIComponent(encodeURIComponent(showStyleBaseId))
+	}
+	getShelfLink (rundownId, layoutId) {
+		// double encoding so that "/" are handled correctly
+		return '/rundown/' + encodeURIComponent(encodeURIComponent(rundownId)) + '/shelf/?layout=' + encodeURIComponent(encodeURIComponent(layoutId))
+	}
+	getRundownWithLayoutLink (rundownId, layoutId) {
+		// double encoding so that "/" are handled correctly
+		return '/rundown/' + encodeURIComponent(encodeURIComponent(rundownId)) + '?layout=' + encodeURIComponent(encodeURIComponent(layoutId))
 	}
 
 	confirmDelete (rundown: Rundown) {
@@ -88,6 +105,46 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 				t('Please note: This action is irreversible!')
 			)
 		})
+	}
+
+	saveViewChoice (key: string) {
+		UIStateStorage.setItem(`rundownList.${this.props.rundown.showStyleVariantId}`, 'defaultView', key)
+	}
+
+	renderViewLinks () {
+		const standaloneLayouts = this.props.rundownLayouts.filter(layout => layout.exposeAsStandalone).map(layout => {
+			const key = `standalone${layout._id}`
+			return (
+				<Link to={this.getShelfLink(this.props.rundown._id, layout._id)} onClick={() => this.saveViewChoice(key)} key={key}>
+					<div className='action-btn expco-item'>
+						<div className='action-btn layout-indicator' style={{ backgroundColor: layout.color }}></div>
+						{layout.name}
+					</div>
+				</Link>
+			)
+		})
+		const shelfLayouts = this.props.rundownLayouts.filter(layout => layout.exposeAsShelf).map(layout => {
+			const key = `shelf${layout._id}`
+			return (
+				<Link to={this.getRundownWithLayoutLink(this.props.rundown._id, layout._id)} onClick={() => this.saveViewChoice(key)} key={key}>
+					<div className='action-btn expco-item'>
+						<div className='action-btn layout-indicator' style={{ backgroundColor: layout.color }}></div>
+						{layout.name}
+					</div>
+				</Link>
+			)
+		})
+		const allElements = [
+			<div className='expco-header' key={'separator0'}>Standalone shelfs</div>,
+			...standaloneLayouts,
+			<div className='expco-header' key={'separator1'}>Rundown + Shelf</div>,
+			...shelfLayouts,
+			<div className='expco-separator' key={'separator2'}></div>,
+			<Link to={this.getRundownLink(this.props.rundown._id)} onClick={() => this.saveViewChoice('default')} key={'default'}><div className='action-btn expco-item'>Default</div></Link>
+		]
+		return <React.Fragment>
+			<SplitDropdown selectedKey={this.state.selectedView} elements={allElements}/>
+		</React.Fragment>
 	}
 
 	render () {
@@ -142,6 +199,9 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 					<td className='rundown-list-item__air-status'>
 						{this.props.rundown.airStatus}
 					</td>
+					<td className='rundown-list-item__views'>
+						{this.renderViewLinks()}
+					</td>
 					<td className='rundown-list-item__actions'>
 						{
 							(this.props.rundown.unsynced || getAllowConfigure() || getAllowService()) ?
@@ -189,6 +249,7 @@ enum ToolTipStep {
 interface IRundownsListProps {
 	coreSystem: ICoreSystem
 	rundowns: Array<RundownUI>
+	rundownLayouts: Array<RundownLayoutBase>
 }
 
 interface IRundownsListState {
@@ -203,6 +264,9 @@ export const RundownList = translateWithTracker(() => {
 	const studios = Studios.find().fetch()
 	const showStyleBases = ShowStyleBases.find().fetch()
 	const showStyleVariants = ShowStyleVariants.find().fetch()
+	const rundownLayouts = RundownLayouts.find({
+		$or: [{ exposeAsStandalone: true }, { exposeAsShelf: true }]
+	}).fetch()
 
 	return {
 		coreSystem: getCoreSystem(),
@@ -217,7 +281,8 @@ export const RundownList = translateWithTracker(() => {
 				showStyleBaseName: showStyleBase && showStyleBase.name || 'N/A',
 				showStyleVariantName: showStyleVariant && showStyleVariant.name || 'N/A'
 			}
-		})
+		}),
+		rundownLayouts
 	}
 })(
 class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsListState> {
@@ -267,6 +332,7 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 
 		this.subscribe(PubSub.rundowns, {})
 		this.subscribe(PubSub.studios, {})
+		this.subscribe(PubSub.rundownLayouts, {})
 
 		this.autorun(() => {
 			const showStyleBaseIds = _.uniq(_.map(Rundowns.find().fetch(), rundown => rundown.showStyleBaseId))
@@ -336,7 +402,7 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 
 		return list.length > 0 ?
 			list.map((rundown) => (
-				<RundownListItem key={rundown._id} rundown={rundown} t={this.props.t} />
+				<RundownListItem key={rundown._id} rundown={rundown} t={this.props.t} rundownLayouts={this.props.rundownLayouts} />
 			)) :
 			<tr>
 				<td colSpan={9}>{t('There are no rundowns ingested into Sofie.')}</td>
@@ -426,6 +492,9 @@ class extends MeteorReactComponent<Translated<IRundownsListProps>, IRundownsList
 									</th>
 									<th className='c1'>
 										{t('Air Status')}
+									</th>
+									<th className='c1'>
+										{t('Views')}
 									</th>
 									<th className='c1'>
 										&nbsp;

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -126,6 +126,7 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 	}
 
 	renderViewLinks () {
+		const { t } = this.props
 		const standaloneLayouts = this.props.rundownLayouts.filter(layout => layout.exposeAsStandalone).map(layout => {
 			return this.renderLinkItem(layout, this.getShelfLink(this.props.rundown._id, layout._id), `standalone${layout._id}`)
 		})
@@ -133,13 +134,11 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 			return this.renderLinkItem(layout, this.getRundownWithLayoutLink(this.props.rundown._id, layout._id), `shelf${layout._id}`)
 		})
 		const allElements = [
-			<div className='expco-header' key={'header1'}>Standalone shelfs</div>,
 			...standaloneLayouts,
-			<div className='expco-header' key={'header2'}>Rundown + Shelf</div>,
+			<div className='expco-header' key={'header2'}>{t('Timeline views')}</div>,
 			...shelfLayouts,
-			<div className='expco-separator' key={'separator1'}></div>,
 			<Link to={this.getRundownLink(this.props.rundown._id)} onClick={() => this.saveViewChoice('default')} key={'default'}>
-				<div className='action-btn expco-item'>Default</div>
+				<div className='action-btn expco-item'>{t('Default')}</div>
 			</Link>
 		]
 		return (

--- a/meteor/client/ui/RundownList.tsx
+++ b/meteor/client/ui/RundownList.tsx
@@ -31,6 +31,7 @@ import { Spinner } from '../lib/Spinner'
 import { SplitDropdown } from '../lib/splitDropdown'
 import { RundownLayoutBase, RundownLayouts } from '../../lib/collections/RundownLayouts'
 import { UIStateStorage } from '../lib/UIStateStorage'
+import * as ClassNames from 'classnames'
 
 const PackageInfo = require('../../package.json')
 
@@ -111,40 +112,41 @@ export class RundownListItem extends React.Component<Translated<IRundownListItem
 		UIStateStorage.setItem(`rundownList.${this.props.rundown.showStyleVariantId}`, 'defaultView', key)
 	}
 
+	renderLinkItem (layout: RundownLayoutBase, link: string, key: string) {
+		return (
+			<Link to={link} onClick={() => this.saveViewChoice(key)} key={key}>
+				<div className='action-btn expco-item'>
+					<div className={ClassNames('action-btn layout-icon', { small: !layout.icon })} style={{ color: layout.iconColor || 'transparent' }}>
+						<FontAwesomeIcon icon={layout.icon || 'circle'} />
+					</div>
+					{layout.name}
+				</div>
+			</Link>
+		)
+	}
+
 	renderViewLinks () {
 		const standaloneLayouts = this.props.rundownLayouts.filter(layout => layout.exposeAsStandalone).map(layout => {
-			const key = `standalone${layout._id}`
-			return (
-				<Link to={this.getShelfLink(this.props.rundown._id, layout._id)} onClick={() => this.saveViewChoice(key)} key={key}>
-					<div className='action-btn expco-item'>
-						<div className='action-btn layout-indicator' style={{ backgroundColor: layout.color }}></div>
-						{layout.name}
-					</div>
-				</Link>
-			)
+			return this.renderLinkItem(layout, this.getShelfLink(this.props.rundown._id, layout._id), `standalone${layout._id}`)
 		})
 		const shelfLayouts = this.props.rundownLayouts.filter(layout => layout.exposeAsShelf).map(layout => {
-			const key = `shelf${layout._id}`
-			return (
-				<Link to={this.getRundownWithLayoutLink(this.props.rundown._id, layout._id)} onClick={() => this.saveViewChoice(key)} key={key}>
-					<div className='action-btn expco-item'>
-						<div className='action-btn layout-indicator' style={{ backgroundColor: layout.color }}></div>
-						{layout.name}
-					</div>
-				</Link>
-			)
+			return this.renderLinkItem(layout, this.getRundownWithLayoutLink(this.props.rundown._id, layout._id), `shelf${layout._id}`)
 		})
 		const allElements = [
-			<div className='expco-header' key={'separator0'}>Standalone shelfs</div>,
+			<div className='expco-header' key={'header1'}>Standalone shelfs</div>,
 			...standaloneLayouts,
-			<div className='expco-header' key={'separator1'}>Rundown + Shelf</div>,
+			<div className='expco-header' key={'header2'}>Rundown + Shelf</div>,
 			...shelfLayouts,
-			<div className='expco-separator' key={'separator2'}></div>,
-			<Link to={this.getRundownLink(this.props.rundown._id)} onClick={() => this.saveViewChoice('default')} key={'default'}><div className='action-btn expco-item'>Default</div></Link>
+			<div className='expco-separator' key={'separator1'}></div>,
+			<Link to={this.getRundownLink(this.props.rundown._id)} onClick={() => this.saveViewChoice('default')} key={'default'}>
+				<div className='action-btn expco-item'>Default</div>
+			</Link>
 		]
-		return <React.Fragment>
-			<SplitDropdown selectedKey={this.state.selectedView} elements={allElements}/>
-		</React.Fragment>
+		return (
+			<React.Fragment>
+				<SplitDropdown selectedKey={this.state.selectedView} elements={allElements}/>
+			</React.Fragment>
+		)
 	}
 
 	render () {

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -711,10 +711,22 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 								</div>
 								<div className='mod mvs mhs'>
 									<label className='field'>
-										{t('Label color')}
+										{t('Icon')}
 										<EditAttribute
 											modifiedClassName='bghl'
-											attribute={'color'}
+											attribute={'icon'}
+											obj={item}
+											type='iconpicker'
+											collection={RundownLayouts}
+											className='input text-input input-s'></EditAttribute>
+									</label>
+								</div>
+								<div className='mod mvs mhs'>
+									<label className='field'>
+										{t('Icon color')}
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'iconColor'}
 											obj={item}
 											options={defaultColorPickerPalette}
 											type='colorpicker'

--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -18,6 +18,7 @@ import { UploadButton } from '../../lib/uploadButton'
 import { doModalDialog } from '../../lib/ModalDialog'
 import { NotificationCenter, Notification, NoticeLevel } from '../../lib/notifications/notifications'
 import { fetchFrom } from '../../lib/lib'
+import { defaultColorPickerPalette } from '../../lib/colorPicker'
 // import { Link } from 'react-router-dom'
 
 export interface IProps {
@@ -680,6 +681,45 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 											type='dropdown'
 											collection={RundownLayouts}
 											className='input text-input input-l'></EditAttribute>
+									</label>
+								</div>
+								<div className='mod mvs mhs'>
+									<label className='field'>
+										{t('Expose layout as a standalone page')}
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'exposeAsStandalone'}
+											obj={item}
+											options={RundownLayoutType}
+											type='checkbox'
+											collection={RundownLayouts}
+											className='mod mas'></EditAttribute>
+									</label>
+								</div>
+								<div className='mod mvs mhs'>
+									<label className='field'>
+										{t('Expose as a layout for the shelf')}
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'exposeAsShelf'}
+											obj={item}
+											options={RundownLayoutType}
+											type='checkbox'
+											collection={RundownLayouts}
+											className='mod mas'></EditAttribute>
+									</label>
+								</div>
+								<div className='mod mvs mhs'>
+									<label className='field'>
+										{t('Label color')}
+										<EditAttribute
+											modifiedClassName='bghl'
+											attribute={'color'}
+											obj={item}
+											options={defaultColorPickerPalette}
+											type='colorpicker'
+											collection={RundownLayouts}
+											className='input text-input input-s'></EditAttribute>
 									</label>
 								</div>
 							</div>

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -106,6 +106,9 @@ export interface RundownLayoutBase {
 	name: string
 	type: RundownLayoutType.RUNDOWN_LAYOUT | RundownLayoutType.DASHBOARD_LAYOUT
 	filters: RundownLayoutElementBase[]
+	exposeAsStandalone: boolean
+	exposeAsShelf: boolean
+	color: string
 }
 
 export interface RundownLayout extends RundownLayoutBase {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -108,7 +108,8 @@ export interface RundownLayoutBase {
 	filters: RundownLayoutElementBase[]
 	exposeAsStandalone: boolean
 	exposeAsShelf: boolean
-	color: string
+	icon: string
+	iconColor: string
 }
 
 export interface RundownLayout extends RundownLayoutBase {

--- a/meteor/server/api/rundownLayouts.ts
+++ b/meteor/server/api/rundownLayouts.ts
@@ -19,7 +19,9 @@ export function createRundownLayout (
 	type: RundownLayoutType,
 	showStyleBaseId: string,
 	blueprintId: string | undefined,
-	userId?: string | undefined
+	userId?: string | undefined,
+	exposeAsStandalone?: boolean,
+	exposeAsShelf?: boolean
 ) {
 	RundownLayouts.insert(literal<RundownLayoutBase>({
 		_id: Random.id(),
@@ -28,7 +30,10 @@ export function createRundownLayout (
 		blueprintId,
 		filters: [],
 		type,
-		userId
+		userId,
+		exposeAsStandalone: !!exposeAsStandalone,
+		exposeAsShelf: !!exposeAsShelf,
+		color: '#ffffff'
 	}))
 }
 

--- a/meteor/server/api/rundownLayouts.ts
+++ b/meteor/server/api/rundownLayouts.ts
@@ -33,7 +33,8 @@ export function createRundownLayout (
 		userId,
 		exposeAsStandalone: !!exposeAsStandalone,
 		exposeAsShelf: !!exposeAsShelf,
-		color: '#ffffff'
+		icon: '',
+		iconColor: '#ffffff'
 	}))
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
This PR adds dropdowns to rundows on the rundown list. A dropdown displays links to available views for every enabled rundown/dashboard layout: 
    - `rundown/<rundownId>/shelf/?layout=<layoutId>` Enabled in layout editor by selecting _Expose layout as a standalone page_

    - `rundown/<rundownId>/?layout=<layoutId>` Enabled in layout editor by selecting _Expose as a layout for the shelf_

    - `rundown/<rundownId>/` (Default)

    Last chosen view for a showstyle is saved for a particular client, and displayed as the top(selected) link of the dropdown.
    The layout editor allows selecting a color and an icon, which is displayed to the left of layout name in the dropdown.


