### PR TITLE
feat: Add VizMSE Clear-all commands settings

### DIFF
--- a/meteor/client/styles/editAttribute.scss
+++ b/meteor/client/styles/editAttribute.scss
@@ -3,7 +3,14 @@
     select,
     input,
     textarea
-     {
+    {
         color: #000;
     }
+}
+
+textarea {
+	&.medium {
+		height: 6em;
+		vertical-align: middle;
+	}
 }

--- a/meteor/client/ui/Settings/components/PlayoutDeviceSettingsComponent.tsx
+++ b/meteor/client/ui/Settings/components/PlayoutDeviceSettingsComponent.tsx
@@ -543,6 +543,14 @@ export const PlayoutDeviceSettingsComponent = translate()(class PlayoutDeviceSet
 				</label>
 			</div>
 			<div className='mod mvs mhs'>
+				<label className='field' title={t('List of commands to send to Viz Engines in order to clear their output. One command per line.')}>
+					<span>{t('Clear-All commands')}</span>
+					<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.options.clearAllCommands'} obj={this.props.device} type='multiline' collection={PeripheralDevices} className='input text-input input-l nw medium'
+						mutateDisplayValue={(v) => (v === undefined || v.length === 0) ? undefined : v.join('\n')}
+						mutateUpdateValue={(v) => (v === undefined || v.length === 0) ? undefined : v.split('\n').map(i => i.trimStart())}></EditAttribute>
+				</label>
+			</div>
+			<div className='mod mvs mhs'>
 				<label className='field'>
 					{t('Clear-All on make-ready (activate rundown)')}
 					<EditAttribute modifiedClassName='bghl' attribute={'settings.devices.' + deviceId + '.options.clearAllOnMakeReady'} obj={this.props.device} type='checkbox' collection={PeripheralDevices} className='input'></EditAttribute>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a _Clear-All Commands_ setting for the VizMSE device. 
In a textarea, multiple commands can be entered in separate lines. 
These commands are sent to Viz Engines in order to fully clear their outputs, which is triggered by a `TimelineObjVIZMSEClearAllElements` and on `makeReady`.

* **Other information**:
It depends on https://github.com/olzzon/tv-automation-state-timeline-resolver/pull/14