### PR TITLE
fix: Appending part notes to segment notes

### DIFF
--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -285,7 +285,7 @@ export class Rundown implements DBRundown {
 			rank: segment._rank,
 			notes: segment.notes
 		} ])) as { [key: string ]: { notes: GenericNote[], rank: number } } 
-		this.getParts().map(part => part.notes && segmentNotes[part.segmentId] && segmentNotes[part.segmentId].notes.concat(part.notes))
+		this.getParts().forEach(part => part.notes && segmentNotes[part.segmentId] && segmentNotes[part.segmentId].notes.push(...part.notes))
 		notes = notes.concat(_.flatten(_.map(_.values(segmentNotes), (o) => {
 			return o.notes.map(note => _.extend(note, {
 				rank: o.rank


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a bug where Part Notes were not appended to Segment Notes because `concat` does not modify the original array, but returns a copy