### PR TITLE
feat: Add JSON config manifest entry with simple validation

### DIFF
--- a/meteor/client/lib/EditAttribute.tsx
+++ b/meteor/client/lib/EditAttribute.tsx
@@ -9,11 +9,12 @@ import { Mongo } from 'meteor/mongo'
 import { MultiSelect, MultiSelectEvent } from './multiSelect'
 import { ColorPickerEvent, ColorPicker } from './colorPicker'
 import { IconPicker, IconPickerEvent } from './iconPicker'
+import * as classNames from 'classnames'
 
 interface IEditAttribute extends IEditAttributeBaseProps {
 	type: EditAttributeType
 }
-export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect' | 'colorpicker' | 'iconpicker'
+export type EditAttributeType = 'text' | 'multiline' | 'int' | 'float' | 'checkbox' | 'dropdown' | 'switch' | 'multiselect' | 'colorpicker' | 'iconpicker' | 'json'
 export class EditAttribute extends React.Component<IEditAttribute> {
 	render () {
 
@@ -57,6 +58,10 @@ export class EditAttribute extends React.Component<IEditAttribute> {
 			return (
 				<EditAttributeIconPicker {...this.props} />
 			)
+		} else if (this.props.type === 'json') {
+			return (
+				<EditAttributeJson {...this.props} />
+			)
 		}
 
 		return <div>Unknown edit type {this.props.type}</div>
@@ -73,6 +78,7 @@ interface IEditAttributeBaseProps {
 	optionsAreNumbers?: boolean
 	className?: string
 	modifiedClassName?: string
+	invalidClassName?: string
 	updateFunction?: (edit: EditAttributeBase, newValue: any) => void
 	overrideDisplayValue?: any
 	label?: string
@@ -628,6 +634,70 @@ const EditAttributeIconPicker = wrapEditAttribute(class extends EditAttributeBas
 				placeholder={this.props.label}
 				onChange={this.handleChange}>
 			</IconPicker>
+		)
+	}
+})
+const EditAttributeJson = wrapEditAttribute(class extends EditAttributeBase {
+	constructor (props) {
+		super(props)
+
+		this.handleChange = this.handleChange.bind(this)
+		this.handleBlur = this.handleBlur.bind(this)
+		this.handleEscape = this.handleEscape.bind(this)
+	}
+	isJson (str: string) {
+		try {
+			JSON.parse(str)
+		} catch (err) {
+			return false
+		}
+		return true
+	}
+	handleChange (event) {
+		let v = event.target.value
+		if (this.isJson(v)) {
+			this.handleEdit(v)
+			this.setState({
+				valueError: false
+			})
+		} else {
+			this.handleUpdateButDontSave(v, true)
+		}
+	}
+	handleBlur (event) {
+		let v = event.target.value
+		if (v === '') {
+			v = '{}'
+		}
+		if (this.isJson(v)) {
+			this.handleUpdate(v)
+			this.setState({
+				valueError: false
+			})
+		} else {
+			this.handleUpdateButDontSave(v, true)
+			this.setState({
+				valueError: true
+			})
+		}
+	}
+	handleEscape (event) {
+		let e = event as KeyboardEvent
+		if (e.key === 'Escape') {
+			this.handleDiscard()
+		}
+	}
+	render () {
+		return (
+			<input type='text'
+				className={classNames('form-control', this.props.className, this.state.valueError && this.props.invalidClassName ? this.props.invalidClassName : this.state.editing ? (this.props.modifiedClassName || '') : '')}
+				placeholder={this.props.label}
+
+				value={this.getEditAttribute() || ''}
+				onChange={this.handleChange}
+				onBlur={this.handleBlur}
+				onKeyUp={this.handleEscape}
+			/>
 		)
 	}
 })

--- a/meteor/client/styles/editAttribute.scss
+++ b/meteor/client/styles/editAttribute.scss
@@ -14,3 +14,7 @@ textarea {
 		vertical-align: middle;
 	}
 }
+
+.warn:focus {
+	color: #FFFFFF;
+}

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -88,6 +88,15 @@ function getEditAttribute<TObj, TObj2> (collection: TransformedCollection<TObj2,
 				options={item2.options || []}
 				collection={collection}
 				className='input text-input input-l' />
+		case ConfigManifestEntryType.JSON:
+			return <EditAttribute
+				modifiedClassName='bghl'
+				invalidClassName='error'
+				attribute={attribute}
+				obj={object}
+				type='json'
+				collection={collection}
+				className='input text-input input-l' />
 		case ConfigManifestEntryType.SELECT:
 			const selectFromOptions = item as ConfigManifestEntrySelectFromOptions<true | false>
 			return <EditAttribute

--- a/meteor/client/ui/Settings/ConfigManifestSettings.tsx
+++ b/meteor/client/ui/Settings/ConfigManifestSettings.tsx
@@ -91,7 +91,7 @@ function getEditAttribute<TObj, TObj2> (collection: TransformedCollection<TObj2,
 		case ConfigManifestEntryType.JSON:
 			return <EditAttribute
 				modifiedClassName='bghl'
-				invalidClassName='error'
+				invalidClassName='warn'
 				attribute={attribute}
 				obj={object}
 				type='json'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds support for JSON entries in Config Manifest. A new type of EditAttribute is added. It has simple validation to indicate when the entered value fails to parse as JSON.

* **Other information**:
Depends on https://github.com/olzzon/tv-automation-sofie-blueprints-integration/pull/2