### PR TITLE
fix: prevent a crash in getTimelineRundown by onTimelineGenerate

### DIFF
--- a/meteor/server/api/playout/timeline.ts
+++ b/meteor/server/api/playout/timeline.ts
@@ -254,30 +254,34 @@ function getTimelineRundown(cache: CacheForRundownPlaylist, studio: Studio): Tim
 				const currentPart = currentPartInstance
 				const context = new PartEventContext(activeRundown, studio, currentPart)
 				const resolvedPieces = getResolvedPiecesFromFullTimeline(cache, playlist, timelineObjs)
-				const tlGenRes = waitForPromise(
-					showStyleBlueprintManifest.onTimelineGenerate(
-						context,
-						timelineObjs,
-						playlist.previousPersistentState,
-						currentPart.part.previousPartEndState,
-						unprotectObjectArray(resolvedPieces.pieces)
+				try {
+					const tlGenRes = waitForPromise(
+						showStyleBlueprintManifest.onTimelineGenerate(
+							context,
+							timelineObjs,
+							playlist.previousPersistentState,
+							currentPart.part.previousPartEndState,
+							unprotectObjectArray(resolvedPieces.pieces)
+						)
 					)
-				)
-				timelineObjs = _.map(tlGenRes.timeline, (object: OnGenerateTimelineObj) => {
-					return literal<TimelineObjGeneric & OnGenerateTimelineObj>({
-						...object,
-						_id: protectString(''), // set later
-						objectType: TimelineObjType.RUNDOWN,
-						studioId: studio._id,
+					timelineObjs = _.map(tlGenRes.timeline, (object: OnGenerateTimelineObj) => {
+						return literal<TimelineObjGeneric & OnGenerateTimelineObj>({
+							...object,
+							_id: protectString(''), // set later
+							objectType: TimelineObjType.RUNDOWN,
+							studioId: studio._id,
+						})
 					})
-				})
-				// TODO - is this the best place for this save?
-				if (tlGenRes.persistentState) {
-					cache.RundownPlaylists.update(playlist._id, {
-						$set: {
-							previousPersistentState: tlGenRes.persistentState,
-						},
-					})
+					// TODO - is this the best place for this save?
+					if (tlGenRes.persistentState) {
+						cache.RundownPlaylists.update(playlist._id, {
+							$set: {
+								previousPersistentState: tlGenRes.persistentState,
+							},
+						})
+					}
+				} catch (e) {
+					logger.error(`Error in onTimelineGenerate during getTimelineRundown`, e)
 				}
 			}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes an issue with getTimelineRundown.

* **What is the current behavior?** (You can also link to an open issue here)

If a ShowStyle blueprint function called `onTimelineGenerate` crashes when run by `getTimelineRundown` in `timeline.ts`, it can silently prevent playback of a newly taken part. The part becomes the current part and simulated initial playback in the GUI happens (based on the `taken` timestamp), but no actual playout by the playout gateway is done, because `updateTimeline` never finishes and no new timeline is generated. I do not belive this is acceptable behavior.

* **What is the new behavior (if this is a feature change)?**

The call to `onTimelineGenerate` is wrapped in a try-catch statement. While I acknowledge that Blueprints use `onTimelineGenerate` to provide custom functionality such as A/B playback and such, I do not believe it's acceptable for a crash in this function to silently prevent playback. Since it's not possible to provide the user with feedback that the part cannot be played at this stage, I believe it's better to attempt playback with the timeline as described by the Pieces contents with a best-effort approach and log an error.

* **Other information**:

There is a sister PR in: https://github.com/nrkno/tv-automation-server-core/pull/285