### PR TITLE
fix: Unsync segments instead of the rundown when allowed

### DIFF
--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -750,16 +750,7 @@ function updateRundownFromIngestData(
 	)
 
 	if (Settings.allowUnsyncedSegments) {
-		if (
-			!isUpdateAllowed(
-				cache,
-				dbPlaylist,
-				dbRundown,
-				{ changed: [dbRundown] },
-				prepareSaveSegments,
-				prepareSaveParts
-			)
-		) {
+		if (!isUpdateAllowed(cache, dbPlaylist, dbRundown, { changed: [dbRundown] })) {
 			ServerRundownAPI.unsyncRundownInner(cache, dbRundown._id)
 			waitForPromise(cache.saveAllToDatabase())
 			return false
@@ -1030,7 +1021,11 @@ function handleRemovedSegment(
 
 		if (canBeUpdated(rundown, segment)) {
 			if (!isUpdateAllowed(cache, playlist, rundown, {}, { removed: [segment] }, {})) {
-				ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+				if (Settings.allowUnsyncedSegments) {
+					ServerRundownAPI.unsyncSegmentInner(cache, rundown._id, segmentId)
+				} else {
+					ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+				}
 			} else {
 				if (removeSegments(cache, rundownId, [segmentId]) === 0) {
 					throw new Meteor.Error(
@@ -1184,7 +1179,11 @@ function updateSegmentFromIngestData(
 
 	// determine if update is allowed here
 	if (!isUpdateAllowed(cache, playlist, rundown, {}, { changed: [newSegment] }, prepareSaveParts)) {
-		ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+		if (Settings.allowUnsyncedSegments) {
+			ServerRundownAPI.unsyncSegmentInner(cache, rundown._id, segmentId)
+		} else {
+			ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+		}
 		return null
 	}
 
@@ -1308,7 +1307,11 @@ export function handleRemovedPart(
 			if (!part) throw new Meteor.Error(404, 'Part not found')
 
 			if (!isUpdateAllowed(cache, playlist, rundown, {}, {}, { removed: [part] })) {
-				ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+				if (Settings.allowUnsyncedSegments) {
+					ServerRundownAPI.unsyncSegmentInner(cache, rundown._id, segmentId)
+				} else {
+					ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+				}
 			} else {
 				// Blueprints will handle the deletion of the Part
 				const ingestSegment = loadCachedIngestSegment(
@@ -1376,7 +1379,11 @@ export function handleUpdatedPartInner(
 	})
 
 	if (part && !isUpdateAllowed(cache, playlist, rundown, {}, {}, { changed: [part] })) {
-		ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+		if (Settings.allowUnsyncedSegments) {
+			ServerRundownAPI.unsyncSegmentInner(cache, rundown._id, segmentId)
+		} else {
+			ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
+		}
 	} else {
 		// Blueprints will handle the creation of the Part
 		const ingestSegment: LocalIngestSegment = loadCachedIngestSegment(


### PR DESCRIPTION
When the allowUnsyncedSegments setting is enabled, and a segment or a part is removed or updated, only the segment will get unsynced, instead of the rundown