### PR TITLE
fix: Remove a segment when device can't find it

### DIFF
--- a/meteor/server/api/ingest/genericDevice/actions.ts
+++ b/meteor/server/api/ingest/genericDevice/actions.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../logging'
 import { PeripheralDeviceAPI } from '../../../../lib/api/peripheralDevice'
 import * as _ from 'underscore'
 import { IngestRundown, IngestSegment } from 'tv-automation-sofie-blueprints-integration'
-import { handleUpdatedSegment, handleUpdatedRundown } from '../rundownInput'
+import { handleRemovedSegment, handleUpdatedSegment, handleUpdatedRundown } from '../rundownInput'
 import { Segment } from '../../../../lib/collections/Segments'
 
 export namespace GenericDeviceActions {
@@ -88,6 +88,7 @@ export namespace GenericDeviceActions {
 			(err: Error, ingestSegment: IngestSegment | null) => {
 				if (err) {
 					if (_.isString(err) && err.match(/segment does not exist/i)) {
+						handleRemovedSegment(peripheralDevice, rundown.externalId, segment.externalId)
 						// Don't throw an error, instead return MISSING value
 						cb(null, TriggerReloadDataResponse.MISSING)
 					} else {

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1000,7 +1000,7 @@ function handleUpdatedRundownPlaylist(
 	saveIntoDb(Rundowns, selector, updated)
 }
 
-function handleRemovedSegment(
+export function handleRemovedSegment(
 	peripheralDevice: PeripheralDevice,
 	rundownExternalId: string,
 	segmentExternalId: string


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR prevents segments from getting stuck, when they become unsynced because of removing from NRCS during their playback. When resyncing a segment, and the ingest gateway says the segment does not exist, we should remove it, because in this case, it most likely got unsynced because of being removed from the NRCS.