### PR TITLE
Feat: Unsynced segment positioning

### DIFF
--- a/meteor/lib/api/rundown.ts
+++ b/meteor/lib/api/rundown.ts
@@ -3,7 +3,7 @@ import { NoteType } from './notes'
 import * as _ from 'underscore'
 import { RundownPlaylistId } from '../collections/RundownPlaylists'
 import { ReloadRundownPlaylistResponse, TriggerReloadDataResponse } from './userActions'
-import { SegmentId } from '../collections/Segments'
+import { SegmentId, SegmentUnsyncedReason } from '../collections/Segments'
 
 export interface RundownPlaylistValidateBlueprintConfigResult {
 	studio: string[]
@@ -26,7 +26,7 @@ export interface NewRundownAPI {
 	resyncRundown(rundownId: RundownId): Promise<TriggerReloadDataResponse>
 	resyncSegment(rundownId: RundownId, segmentId: SegmentId): Promise<TriggerReloadDataResponse>
 	unsyncRundown(rundownId: RundownId): Promise<void>
-	unsyncSegment(rundownId: RundownId, segmentId: SegmentId): Promise<void>
+	unsyncSegment(rundownId: RundownId, segmentId: SegmentId, reason: SegmentUnsyncedReason): Promise<void>
 }
 
 export enum RundownAPIMethods {

--- a/meteor/lib/collections/Rundowns.ts
+++ b/meteor/lib/collections/Rundowns.ts
@@ -84,6 +84,8 @@ export interface DBRundown
 	unsynced?: boolean
 	/** Timestamp of when rundown was unsynced */
 	unsyncedTime?: Time
+	/** Does the rundown contain an unsynced segment? */
+	hasUnsyncedSegment?: boolean
 
 	/** Last sent storyStatus to ingestDevice (MOS) */
 	notifiedCurrentPlayingPartExternalId?: string
@@ -129,6 +131,7 @@ export class Rundown implements DBRundown {
 	public status?: string
 	public airStatus?: string
 	public unsynced?: boolean
+	public hasUnsyncedSegment?: boolean
 	public unsyncedTime?: Time
 	public startedPlayback?: Time
 	public notifiedCurrentPlayingPartExternalId?: string

--- a/meteor/lib/collections/Segments.ts
+++ b/meteor/lib/collections/Segments.ts
@@ -11,6 +11,12 @@ import { createMongoCollection } from './lib'
 /** A string, identifying a Segment */
 export type SegmentId = ProtectedString<'SegmentId'>
 /** A "Title" in NRK Lingo / "Stories" in ENPS Lingo. */
+
+export enum SegmentUnsyncedReason {
+	REMOVED = 1,
+	CHANGED,
+}
+
 export interface DBSegment extends ProtectedStringProperties<IBlueprintSegmentDB, '_id'> {
 	_id: SegmentId
 	/** Position inside rundown */
@@ -26,7 +32,7 @@ export interface DBSegment extends ProtectedStringProperties<IBlueprintSegmentDB
 	expanded?: boolean
 
 	/** Is the segment in an unsynced state? */
-	unsynced?: boolean
+	unsynced?: SegmentUnsyncedReason
 	/** Timestamp of when segment was unsynced */
 	unsyncedTime?: Time
 
@@ -45,7 +51,7 @@ export class Segment implements DBSegment {
 	public expanded?: boolean
 	public notes?: Array<SegmentNote>
 	public isHidden?: boolean
-	public unsynced?: boolean
+	public unsynced?: SegmentUnsyncedReason
 	public unsyncedTime?: Time
 	public identifier?: string
 

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -42,7 +42,7 @@ import {
 import { Rundown, RundownId, Rundowns } from '../../../../lib/collections/Rundowns'
 import { Studio } from '../../../../lib/collections/Studios'
 import { ShowStyleBases } from '../../../../lib/collections/ShowStyleBases'
-import { Segments, Segment } from '../../../../lib/collections/Segments'
+import { Segments, Segment, SegmentUnsyncedReason } from '../../../../lib/collections/Segments'
 import { loadShowStyleBlueprint } from '../../blueprints/cache'
 import { removeSegments, ServerRundownAPI } from '../../rundown'
 import { UpdateNext } from '../updateNext'
@@ -577,7 +577,12 @@ function diffAndApplyChanges(
 				`Currently playing part "${currentPartInstance.part._id}" was removed during ingestData. Unsyncing the rundown!`
 			)
 			if (Settings.allowUnsyncedSegments) {
-				ServerRundownAPI.unsyncSegmentInner(cache, rundown._id, currentPartInstance.part.segmentId)
+				ServerRundownAPI.unsyncSegmentInner(
+					cache,
+					rundown._id,
+					currentPartInstance.part.segmentId,
+					SegmentUnsyncedReason.CHANGED
+				)
 			} else {
 				ServerRundownAPI.unsyncRundownInner(cache, rundown._id)
 			}

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -383,8 +383,7 @@ export function handleInsertParts(
 		})
 
 		const cache = waitForPromise(initCacheForRundownPlaylist(playlist)) // todo: change this
-		diffAndApplyChanges(cache, studio, playlist, rundown, ingestRundown, newIngestSegments)
-		UpdateNext.afterInsertParts(cache, playlist, newPartIds, removePrevious)
+		diffAndApplyChanges(cache, studio, playlist, rundown, ingestRundown, newIngestSegments, removePrevious)
 		waitForPromise(cache.saveAllToDatabase())
 	})
 }
@@ -550,7 +549,8 @@ function diffAndApplyChanges(
 	playlist: RundownPlaylist,
 	rundown: Rundown,
 	oldIngestRundown: LocalIngestRundown,
-	newIngestSegments: LocalIngestSegment[]
+	newIngestSegments: LocalIngestSegment[],
+	removePreviousParts?: boolean
 	// newIngestParts: AnnotatedIngestPart[]
 ) {
 	// Fetch all existing segments:
@@ -656,7 +656,8 @@ function diffAndApplyChanges(
 		studio,
 		playlist,
 		rundown,
-		_.sortBy([..._.values(segmentDiff.added), ..._.values(segmentDiff.changed)], (se) => se.rank)
+		_.sortBy([..._.values(segmentDiff.added), ..._.values(segmentDiff.changed)], (se) => se.rank),
+		removePreviousParts
 	)
 }
 

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1037,7 +1037,7 @@ export function handleRemovedSegment(
 						`handleRemovedSegment: removeSegments: Segment ${segmentExternalId} not found`
 					)
 				} else {
-					afterIngestChangedData(cache, rundown, [])
+					UpdateNext.ensureNextPartIsValid(cache, playlist)
 				}
 			}
 		}

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1345,7 +1345,7 @@ function afterIngestChangedData(
 	updateExpectedPlayoutItemsOnRundown(cache, rundown._id)
 	updatePartRanks(cache, playlist, changedSegmentIds)
 
-	if (newPartIds && newPartIds.length > 0) {
+	if (newPartIds?.length) {
 		UpdateNext.afterInsertParts(cache, playlist, newPartIds, !!removedPreviousParts)
 	} else {
 		UpdateNext.ensureNextPartIsValid(cache, playlist)

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1345,7 +1345,7 @@ function afterIngestChangedData(
 	updateExpectedPlayoutItemsOnRundown(cache, rundown._id)
 	updatePartRanks(cache, playlist, changedSegmentIds)
 
-	if (newPartIds) {
+	if (newPartIds && newPartIds.length > 0) {
 		UpdateNext.afterInsertParts(cache, playlist, newPartIds, !!removedPreviousParts)
 	} else {
 		UpdateNext.ensureNextPartIsValid(cache, playlist)

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -1168,24 +1168,25 @@ function updateSegmentFromIngestData(
 			let newRank = Number.MIN_SAFE_INTEGER
 			let previousSegment = allSegmentsByRank[removedInd + 1]
 			let nextSegment = allSegmentsByRank[removedInd - 1]
+			let previousPreviousSegment = allSegmentsByRank[removedInd + 2]
 			if (previousSegment) {
 				newRank = previousSegment._rank + eps
 				if (previousSegment._id === segmentId) {
 					if (previousSegment._rank > newSegment._rank) {
 						// moved previous segment up: follow it
 						newRank = newSegment._rank + eps
-					} else if (previousSegment._rank < newSegment._rank && allSegmentsByRank[removedInd + 2]) {
+					} else if (previousSegment._rank < newSegment._rank && previousPreviousSegment) {
 						// moved previous segment down: stay behind more previous
-						newRank = allSegmentsByRank[removedInd + 2]._rank + eps
+						newRank = previousPreviousSegment._rank + eps
 					}
 				} else if (nextSegment && nextSegment._id === segmentId && nextSegment._rank > newSegment._rank) {
 					// next segment was moved up
-					if (allSegmentsByRank[removedInd + 2]) {
-						if (allSegmentsByRank[removedInd + 2]._rank < newSegment._rank) {
+					if (previousPreviousSegment) {
+						if (previousPreviousSegment._rank < newSegment._rank) {
 							// swapped segments directly before and after
 							// will always result in both going below the unsynced
 							// will also affect multiple segments moved directly above the previous
-							newRank = allSegmentsByRank[removedInd + 2]._rank + eps
+							newRank = previousPreviousSegment._rank + eps
 						}
 					} else {
 						newRank = Number.MIN_SAFE_INTEGER


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds logic that modifies the rank of a segment that was removed from the rundown in NRCS, but was live in Sofie and is left as unsynced. The implemented logic:
If there were no other stories in NRCS, and only the unsynced one left in Sofie, the unsynced one receives negative rank, and everything that's added later stays below that one. 
If there are other stories, the unsynced one glues to the previous one. If new segments are added after the previous one, they will be placed after the unsynced one. If we move the previous somewhere, the unsynced one will glue to the segment that was before the moved. Rare edge case: swaping the segments directly before and after the unsynced one will always lead to placing them both below the unsynced, because we can't say what the real intention was.

This PR also fixes the missing logic for updating the next segment in case the currently next segment was deleted, and in case new segments are added while there is no next segment.