### PR TITLE
Perf: Ingest performance

### DIFF
--- a/meteor/server/__tests__/codeControl.test.ts
+++ b/meteor/server/__tests__/codeControl.test.ts
@@ -18,7 +18,9 @@ describe('codeControl rundown', () => {
 	})
 	testInFiber('rundownSyncFunction', () => {
 		let sync1 = (name: string, priority: RundownSyncFunctionPriority) => {
-			return rundownPlaylistSyncFunction(protectString('ro1'), priority, () => takesALongTimeInner(name))
+			return rundownPlaylistSyncFunction(protectString('ro1'), priority, 'testRundownSyncFn', () =>
+				takesALongTimeInner(name)
+			)
 		}
 
 		let res: any[] = []

--- a/meteor/server/api/ingest/actions.ts
+++ b/meteor/server/api/ingest/actions.ts
@@ -119,34 +119,41 @@ export namespace IngestActions {
 			)
 		}
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.INGEST, () => {
-			cache.Rundowns.findFetch({ playlistId: rundownPlaylist._id }).forEach((rundown) => {
-				if (rundown.studioId !== studio._id) {
-					logger.warning(
-						`Rundown "${rundown._id}" does not belong to the same studio as its playlist "${rundownPlaylist._id}"`
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.INGEST,
+			'regenerateRundownPlaylist',
+			() => {
+				cache.Rundowns.findFetch({ playlistId: rundownPlaylist._id }).forEach((rundown) => {
+					if (rundown.studioId !== studio._id) {
+						logger.warning(
+							`Rundown "${rundown._id}" does not belong to the same studio as its playlist "${rundownPlaylist._id}"`
+						)
+					}
+					const peripheralDevice = waitForPromise(cache.activationCache.getPeripheralDevices()).find(
+						(d) => d._id === rundown.peripheralDeviceId
 					)
-				}
-				const peripheralDevice = waitForPromise(cache.activationCache.getPeripheralDevices()).find(
-					(d) => d._id === rundown.peripheralDeviceId
-				)
-				if (!peripheralDevice) {
-					logger.info(`Rundown "${rundown._id}" has no valid PeripheralDevices. Running regenerate without`)
-				}
+					if (!peripheralDevice) {
+						logger.info(
+							`Rundown "${rundown._id}" has no valid PeripheralDevices. Running regenerate without`
+						)
+					}
 
-				const ingestRundown = loadCachedRundownData(rundown._id, rundown.externalId)
-				if (purgeExisting) {
-					removeRundownFromCache(cache, rundown)
-				} else {
-					// Reset the rundown (remove adlibs, etc):
-					resetRundown(cache, rundown)
-				}
+					const ingestRundown = loadCachedRundownData(rundown._id, rundown.externalId)
+					if (purgeExisting) {
+						removeRundownFromCache(cache, rundown)
+					} else {
+						// Reset the rundown (remove adlibs, etc):
+						resetRundown(cache, rundown)
+					}
+
+					waitForPromise(cache.saveAllToDatabase())
+
+					handleUpdatedRundownInner(studio, rundown._id, ingestRundown, rundown.dataSource, peripheralDevice)
+				})
 
 				waitForPromise(cache.saveAllToDatabase())
-
-				handleUpdatedRundownInner(studio, rundown._id, ingestRundown, rundown.dataSource, peripheralDevice)
-			})
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+			}
+		)
 	}
 }

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -78,8 +78,10 @@ export function updateExpectedPlayoutItemsOnRundown(cache: CacheForRundownPlayli
 	const adlibPiecesGrouped = _.groupBy(adlibPiecesInThisRundown, 'partId')
 
 	for (const part of cache.Parts.findFetch({ rundownId: rundown._id })) {
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)]))
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)]))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)] || []))
+		intermediaryItems.push(
+			...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)] || [])
+		)
 	}
 
 	cache.deferAfterSave(() => {

--- a/meteor/server/api/ingest/expectedPlayoutItems.ts
+++ b/meteor/server/api/ingest/expectedPlayoutItems.ts
@@ -7,7 +7,7 @@ import { DBRundown, RundownId } from '../../../lib/collections/Rundowns'
 import { AdLibPiece } from '../../../lib/collections/AdLibPieces'
 import { logger } from '../../logging'
 import { PartId, DBPart } from '../../../lib/collections/Parts'
-import { saveIntoDb, protectString } from '../../../lib/lib'
+import { saveIntoDb, protectString, unprotectString } from '../../../lib/lib'
 import { CacheForRundownPlaylist } from '../../DatabaseCaches'
 import { getAllPiecesFromCache, getAllAdLibPiecesFromCache } from '../playout/lib'
 
@@ -67,9 +67,19 @@ export function updateExpectedPlayoutItemsOnRundown(cache: CacheForRundownPlayli
 
 	const intermediaryItems: ExpectedPlayoutItemGenericWithPiece[] = []
 
+	const piecesStartingInThisRundown = cache.Pieces.findFetch({
+		startRundownId: rundown._id,
+	})
+	const piecesGrouped = _.groupBy(piecesStartingInThisRundown, 'startPartId')
+
+	const adlibPiecesInThisRundown = cache.AdLibPieces.findFetch({
+		rundownId: rundown._id,
+	})
+	const adlibPiecesGrouped = _.groupBy(adlibPiecesInThisRundown, 'partId')
+
 	for (const part of cache.Parts.findFetch({ rundownId: rundown._id })) {
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, getAllPiecesFromCache(cache, part)))
-		intermediaryItems.push(...extractExpectedPlayoutItems(part, getAllAdLibPiecesFromCache(cache, part)))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, piecesGrouped[unprotectString(part._id)]))
+		intermediaryItems.push(...extractExpectedPlayoutItems(part, adlibPiecesGrouped[unprotectString(part._id)]))
 	}
 
 	cache.deferAfterSave(() => {

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -219,16 +219,10 @@ export function handleMosRundownMetadata(
 			ingestRundown.modified = getCurrentTime()
 			// TODO - verify this doesn't lose data, it was doing more work before
 
-<<<<<<< HEAD
-		// TODO - make this more lightweight?
-		handleUpdatedRundownInner(studio, rundownId, ingestRundown, 'mosRoMetadata', peripheralDevice)
-	})
-=======
 			// TODO - make this more lightweight?
 			handleUpdatedRundownInner(studio, rundownId, ingestRundown, 'mosRoMetadata', peripheralDevice)
 		}
 	)
->>>>>>> chore: improve context logging for rundownPlaylistSyncFunction
 }
 
 export function handleMosFullStory(peripheralDevice: PeripheralDevice, story: MOS.IMOSROFullStory) {

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -138,7 +138,7 @@ export function handleMosRundownData(
 
 	// Create or update a rundown (ie from rundownCreate or rundownList)
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleMosRundownData', () => {
 		const parts = _.compact(storiesToIngestParts(rundownId, mosRunningOrder.Stories || [], !createFresh, []))
 		const groupedStories = groupIngestParts(parts)
 
@@ -195,29 +195,40 @@ export function handleMosRundownMetadata(
 
 	const playlistId = getRundown(rundownId, mosRunningOrderBase.ID.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
-		const rundown = getRundown(rundownId, parseMosString(mosRunningOrderBase.ID))
-		if (!canBeUpdated(rundown)) return
+	return rundownPlaylistSyncFunction(
+		playlistId,
+		RundownSyncFunctionPriority.INGEST,
+		'handleMosRundownMetadata',
+		() => {
+			const rundown = getRundown(rundownId, parseMosString(mosRunningOrderBase.ID))
+			if (!canBeUpdated(rundown)) return
 
-		// Load the blueprint to process the data
-		const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId)
-		if (!showStyleBase) {
-			throw new Meteor.Error(
-				500,
-				`Failed to ShowStyleBase "${rundown.showStyleBaseId}" for rundown "${rundown._id}"`
-			)
-		}
-		const showStyleBlueprint = loadShowStyleBlueprint(showStyleBase)
+			// Load the blueprint to process the data
+			const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId)
+			if (!showStyleBase) {
+				throw new Meteor.Error(
+					500,
+					`Failed to ShowStyleBase "${rundown.showStyleBaseId}" for rundown "${rundown._id}"`
+				)
+			}
+			const showStyleBlueprint = loadShowStyleBlueprint(showStyleBase)
 
-		// Load the cached RO Data
-		const ingestRundown = loadCachedRundownData(rundown._id, rundown.externalId)
-		ingestRundown.payload = _.extend(ingestRundown.payload, mosRunningOrderBase)
-		ingestRundown.modified = getCurrentTime()
-		// TODO - verify this doesn't lose data, it was doing more work before
+			// Load the cached RO Data
+			const ingestRundown = loadCachedRundownData(rundown._id, rundown.externalId)
+			ingestRundown.payload = _.extend(ingestRundown.payload, mosRunningOrderBase)
+			ingestRundown.modified = getCurrentTime()
+			// TODO - verify this doesn't lose data, it was doing more work before
 
+<<<<<<< HEAD
 		// TODO - make this more lightweight?
 		handleUpdatedRundownInner(studio, rundownId, ingestRundown, 'mosRoMetadata', peripheralDevice)
 	})
+=======
+			// TODO - make this more lightweight?
+			handleUpdatedRundownInner(studio, rundownId, ingestRundown, 'mosRoMetadata', peripheralDevice)
+		}
+	)
+>>>>>>> chore: improve context logging for rundownPlaylistSyncFunction
 }
 
 export function handleMosFullStory(peripheralDevice: PeripheralDevice, story: MOS.IMOSROFullStory) {
@@ -231,7 +242,7 @@ export function handleMosFullStory(peripheralDevice: PeripheralDevice, story: MO
 
 	const playlistId = getRundown(rundownId, story.RunningOrderId.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleMosFullStory', () => {
 		const rundown = getRundown(rundownId, parseMosString(story.RunningOrderId))
 		const playlist = getRundownPlaylist(rundown)
 		// canBeUpdated is done inside handleUpdatedPartInner
@@ -276,7 +287,7 @@ export function handleMosDeleteStory(
 
 	const playlistId = getRundown(rundownId, runningOrderMosId.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleMosDeleteStory', () => {
 		const rundown = getRundown(rundownId, parseMosString(runningOrderMosId))
 		if (!canBeUpdated(rundown)) return
 
@@ -341,7 +352,7 @@ export function handleInsertParts(
 
 	const playlistId = getRundown(rundownId, runningOrderMosId.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleInsertParts', () => {
 		const rundown = getRundown(rundownId, parseMosString(runningOrderMosId))
 		if (!canBeUpdated(rundown)) return
 
@@ -408,7 +419,7 @@ export function handleSwapStories(
 
 	const playlistId = getRundown(rundownId, runningOrderMosId.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleSwapStories', () => {
 		const rundown = getRundown(rundownId, parseMosString(runningOrderMosId))
 		if (!canBeUpdated(rundown)) return
 
@@ -449,7 +460,7 @@ export function handleMoveStories(
 	const rundownId = getRundownIdFromMosRO(studio, runningOrderMosId)
 	const playlistId = getRundown(rundownId, runningOrderMosId.toString()).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleMoveStories', () => {
 		const rundown = getRundown(rundownId, parseMosString(runningOrderMosId))
 		if (!canBeUpdated(rundown)) return
 

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -19,7 +19,6 @@ import {
 	Omit,
 	getRandomId,
 	PreparedChanges,
-	asyncCollectionUpsert,
 } from '../../../lib/lib'
 import {
 	IngestRundown,
@@ -1190,16 +1189,6 @@ function updateSegmentFromIngestData(
 
 	// Update segment info:
 	cache.Segments.upsert(
-		{
-			_id: segmentId,
-			rundownId: rundown._id,
-		},
-		newSegment
-	)
-
-	// Update segment info:
-	const p = asyncCollectionUpsert(
-		Segments,
 		{
 			_id: segmentId,
 			rundownId: rundown._id,

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -131,8 +131,12 @@ export enum RundownSyncFunctionPriority {
 export function rundownPlaylistSyncFunction<T extends Function>(
 	rundownPlaylistId: RundownPlaylistId,
 	priority: RundownSyncFunctionPriority,
+	context: string,
 	fcn: T
 ): ReturnType<T> {
+	if (!fcn.name) {
+		Object.defineProperty(fcn, 'name', { value: context })
+	}
 	return syncFunction(fcn, `ingest_rundown_${rundownPlaylistId}`, undefined, priority)()
 }
 
@@ -345,7 +349,7 @@ export function handleRemovedRundown(peripheralDevice: PeripheralDevice, rundown
 	const rundownId = getRundownId(studio, rundownExternalId)
 	const rundownPlaylistId = getRundown(rundownId, rundownExternalId).playlistId
 
-	rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.INGEST, () => {
+	rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.INGEST, 'handleRemovedRundown', () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const playlist = getRundownPlaylist(rundown)
 
@@ -414,7 +418,7 @@ export function handleUpdatedRundown(
 	// Lock behind a playlist if it exists
 	const existingRundown = Rundowns.findOne(rundownId)
 	const playlistId = existingRundown ? existingRundown.playlistId : protectString('newPlaylist')
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () =>
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleUpdatedRundown', () =>
 		handleUpdatedRundownInner(studio, rundownId, makeNewIngestRundown(ingestRundown), dataSource, peripheralDevice)
 	)
 }
@@ -1008,7 +1012,7 @@ function handleRemovedSegment(
 	const rundownId = getRundownId(studio, rundownExternalId)
 	const playlistId = getRundown(rundownId, rundownExternalId).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleRemovedSegment', () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const playlist = getRundownPlaylist(rundown)
 		const segmentId = getSegmentId(rundown._id, segmentExternalId)
@@ -1047,7 +1051,7 @@ export function handleUpdatedSegment(
 	const rundownId = getRundownId(studio, rundownExternalId)
 	const playlistId = getRundown(rundownId, rundownExternalId).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleUpdatedSegment', () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const playlist = getRundownPlaylist(rundown)
 		const segmentId = getSegmentId(rundown._id, ingestSegment.externalId)
@@ -1278,7 +1282,7 @@ export function handleRemovedPart(
 	const rundownId = getRundownId(studio, rundownExternalId)
 	const playlistId = getRundown(rundownId, rundownExternalId).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleRemovedPart', () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const playlist = getRundownPlaylist(rundown)
 		const segmentId = getSegmentId(rundown._id, segmentExternalId)
@@ -1335,7 +1339,7 @@ export function handleUpdatedPart(
 	const rundownId = getRundownId(studio, rundownExternalId)
 	const playlistId = getRundown(rundownId, rundownExternalId).playlistId
 
-	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, () => {
+	return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.INGEST, 'handleUpdatedPart', () => {
 		const rundown = getRundown(rundownId, rundownExternalId)
 		const playlist = getRundownPlaylist(rundown)
 

--- a/meteor/server/api/playout/adlib.ts
+++ b/meteor/server/api/playout/adlib.ts
@@ -57,100 +57,105 @@ export namespace ServerPlayoutAdLibAPI {
 		partInstanceId: PartInstanceId,
 		pieceInstanceIdOrPieceIdToCopy: PieceInstanceId | PieceId
 	) {
-		return rundownPlaylistSyncFunction(rundownPlaylist._id, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!rundownPlaylist.active)
-				throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
-			if (rundownPlaylist.currentPartInstanceId !== partInstanceId)
-				throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a current part!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylist._id,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'pieceTakeNow',
+			() => {
+				if (!rundownPlaylist.active)
+					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
+				if (rundownPlaylist.currentPartInstanceId !== partInstanceId)
+					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a current part!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
-			const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
+				const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
+				const rundownIds = getRundownIDsFromCache(cache, rundownPlaylist)
 
-			const pieceInstanceToCopy = cache.PieceInstances.findOne({
-				_id: pieceInstanceIdOrPieceIdToCopy as PieceInstanceId,
-				rundownId: { $in: rundownIds },
-			})
-			const pieceToCopy = pieceInstanceToCopy
-				? pieceInstanceToCopy.piece
-				: (Pieces.findOne({
-						_id: pieceInstanceIdOrPieceIdToCopy as PieceId,
-						startRundownId: { $in: rundownIds },
-				  }) as Piece)
-			if (!pieceToCopy) {
-				throw new Meteor.Error(404, `PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" not found!`)
-			}
-
-			const partInstance = cache.PartInstances.findOne(partInstanceId)
-			if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
-
-			const rundown = cache.Rundowns.findOne(partInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
-
-			const showStyleBase = rundown.getShowStyleBase() // todo: database
-			const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === pieceToCopy.sourceLayerId)
-			if (sourceLayer && sourceLayer.type !== SourceLayerType.GRAPHICS)
-				throw new Meteor.Error(
-					403,
-					`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" is not a GRAPHICS item!`
-				)
-
-			const newPieceInstance = convertAdLibToPieceInstance(pieceToCopy, partInstance, false)
-			if (newPieceInstance.piece.content && newPieceInstance.piece.content.timelineObjects) {
-				newPieceInstance.piece.content.timelineObjects = prefixAllObjectIds(
-					_.map(newPieceInstance.piece.content.timelineObjects, (obj) => {
-						return literal<TimelineObjGeneric>({
-							...obj,
-							// @ts-ignore _id
-							_id: obj.id || obj._id,
-							studioId: protectString(''), // set later
-							objectType: TimelineObjType.RUNDOWN,
-						})
-					}),
-					unprotectString(newPieceInstance._id)
-				)
-			}
-
-			// Disable the original piece if from the same Part
-			if (pieceInstanceToCopy && pieceInstanceToCopy.partInstanceId === partInstance._id) {
-				// Ensure the piece being copied isnt currently live
-				if (
-					pieceInstanceToCopy.piece.startedPlayback &&
-					pieceInstanceToCopy.piece.startedPlayback <= getCurrentTime()
-				) {
-					const resolvedPieces = getResolvedPieces(cache, showStyleBase, partInstance)
-					const resolvedPieceBeingCopied = resolvedPieces.find((p) => p._id === pieceInstanceToCopy._id)
-
-					if (
-						resolvedPieceBeingCopied &&
-						resolvedPieceBeingCopied.resolvedDuration !== undefined &&
-						(resolvedPieceBeingCopied.infinite ||
-							resolvedPieceBeingCopied.resolvedStart + resolvedPieceBeingCopied.resolvedDuration >=
-								getCurrentTime())
-					) {
-						// logger.debug(`Piece "${piece._id}" is currently live and cannot be used as an ad-lib`)
-						throw new Meteor.Error(
-							409,
-							`PieceInstance "${pieceInstanceToCopy._id}" is currently live and cannot be used as an ad-lib`
-						)
-					}
+				const pieceInstanceToCopy = cache.PieceInstances.findOne({
+					_id: pieceInstanceIdOrPieceIdToCopy as PieceInstanceId,
+					rundownId: { $in: rundownIds },
+				})
+				const pieceToCopy = pieceInstanceToCopy
+					? pieceInstanceToCopy.piece
+					: (Pieces.findOne({
+							_id: pieceInstanceIdOrPieceIdToCopy as PieceId,
+							startRundownId: { $in: rundownIds },
+					  }) as Piece)
+				if (!pieceToCopy) {
+					throw new Meteor.Error(404, `PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" not found!`)
 				}
 
-				cache.PieceInstances.update(pieceInstanceToCopy._id, {
-					$set: {
-						disabled: true,
-						hidden: true,
-					},
-				})
+				const partInstance = cache.PartInstances.findOne(partInstanceId)
+				if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
+
+				const rundown = cache.Rundowns.findOne(partInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
+
+				const showStyleBase = rundown.getShowStyleBase() // todo: database
+				const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === pieceToCopy.sourceLayerId)
+				if (sourceLayer && sourceLayer.type !== SourceLayerType.GRAPHICS)
+					throw new Meteor.Error(
+						403,
+						`PieceInstance or Piece "${pieceInstanceIdOrPieceIdToCopy}" is not a GRAPHICS item!`
+					)
+
+				const newPieceInstance = convertAdLibToPieceInstance(pieceToCopy, partInstance, false)
+				if (newPieceInstance.piece.content && newPieceInstance.piece.content.timelineObjects) {
+					newPieceInstance.piece.content.timelineObjects = prefixAllObjectIds(
+						_.map(newPieceInstance.piece.content.timelineObjects, (obj) => {
+							return literal<TimelineObjGeneric>({
+								...obj,
+								// @ts-ignore _id
+								_id: obj.id || obj._id,
+								studioId: protectString(''), // set later
+								objectType: TimelineObjType.RUNDOWN,
+							})
+						}),
+						unprotectString(newPieceInstance._id)
+					)
+				}
+
+				// Disable the original piece if from the same Part
+				if (pieceInstanceToCopy && pieceInstanceToCopy.partInstanceId === partInstance._id) {
+					// Ensure the piece being copied isnt currently live
+					if (
+						pieceInstanceToCopy.piece.startedPlayback &&
+						pieceInstanceToCopy.piece.startedPlayback <= getCurrentTime()
+					) {
+						const resolvedPieces = getResolvedPieces(cache, showStyleBase, partInstance)
+						const resolvedPieceBeingCopied = resolvedPieces.find((p) => p._id === pieceInstanceToCopy._id)
+
+						if (
+							resolvedPieceBeingCopied &&
+							resolvedPieceBeingCopied.resolvedDuration !== undefined &&
+							(resolvedPieceBeingCopied.infinite ||
+								resolvedPieceBeingCopied.resolvedStart + resolvedPieceBeingCopied.resolvedDuration >=
+									getCurrentTime())
+						) {
+							// logger.debug(`Piece "${piece._id}" is currently live and cannot be used as an ad-lib`)
+							throw new Meteor.Error(
+								409,
+								`PieceInstance "${pieceInstanceToCopy._id}" is currently live and cannot be used as an ad-lib`
+							)
+						}
+					}
+
+					cache.PieceInstances.update(pieceInstanceToCopy._id, {
+						$set: {
+							disabled: true,
+							hidden: true,
+						},
+					})
+				}
+
+				cache.PieceInstances.insert(newPieceInstance)
+
+				syncPlayheadInfinitesForNextPartInstance(cache, rundownPlaylist)
+
+				updateTimeline(cache, rundown.studioId)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			cache.PieceInstances.insert(newPieceInstance)
-
-			syncPlayheadInfinitesForNextPartInstance(cache, rundownPlaylist)
-
-			updateTimeline(cache, rundown.studioId)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	export function segmentAdLibPieceStart(
 		rundownPlaylist: RundownPlaylist,
@@ -158,44 +163,49 @@ export namespace ServerPlayoutAdLibAPI {
 		adLibPieceId: PieceId,
 		queue: boolean
 	) {
-		return rundownPlaylistSyncFunction(rundownPlaylist._id, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!rundownPlaylist.active)
-				throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
-			if (
-				rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
-				rundownPlaylist.holdState === RundownHoldState.PENDING
-			) {
-				throw new Meteor.Error(403, `Part AdLib-pieces can not be used in combination with hold!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylist._id,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'segmentAdLibPieceStart',
+			() => {
+				if (!rundownPlaylist.active)
+					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in an active rundown!`)
+				if (
+					rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
+					rundownPlaylist.holdState === RundownHoldState.PENDING
+				) {
+					throw new Meteor.Error(403, `Part AdLib-pieces can not be used in combination with hold!`)
+				}
+				const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
+
+				const partInstance = PartInstances.findOne(partInstanceId)
+				if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
+				const rundown = Rundowns.findOne(partInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
+				if (rundown.playlistId !== rundownPlaylist._id)
+					throw new Meteor.Error(
+						406,
+						`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylist._id}!"`
+					)
+
+				const adLibPiece = AdLibPieces.findOne({
+					_id: adLibPieceId,
+					rundownId: partInstance.rundownId,
+				})
+				if (!adLibPiece) throw new Meteor.Error(404, `Part Ad Lib Item "${adLibPieceId}" not found!`)
+				if (adLibPiece.invalid)
+					throw new Meteor.Error(404, `Cannot take invalid Part Ad Lib Item "${adLibPieceId}"!`)
+				if (adLibPiece.floated)
+					throw new Meteor.Error(404, `Cannot take floated Part Ad Lib Item "${adLibPieceId}"!`)
+
+				if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
+					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a currently playing part!`)
+
+				innerStartOrQueueAdLibPiece(cache, rundownPlaylist, rundown, queue, partInstance, adLibPiece)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-			const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
-
-			const partInstance = PartInstances.findOne(partInstanceId)
-			if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
-			const rundown = Rundowns.findOne(partInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
-			if (rundown.playlistId !== rundownPlaylist._id)
-				throw new Meteor.Error(
-					406,
-					`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylist._id}!"`
-				)
-
-			const adLibPiece = AdLibPieces.findOne({
-				_id: adLibPieceId,
-				rundownId: partInstance.rundownId,
-			})
-			if (!adLibPiece) throw new Meteor.Error(404, `Part Ad Lib Item "${adLibPieceId}" not found!`)
-			if (adLibPiece.invalid)
-				throw new Meteor.Error(404, `Cannot take invalid Part Ad Lib Item "${adLibPieceId}"!`)
-			if (adLibPiece.floated)
-				throw new Meteor.Error(404, `Cannot take floated Part Ad Lib Item "${adLibPieceId}"!`)
-
-			if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
-				throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a currently playing part!`)
-
-			innerStartOrQueueAdLibPiece(cache, rundownPlaylist, rundown, queue, partInstance, adLibPiece)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	export function rundownBaselineAdLibPieceStart(
 		rundownPlaylist: RundownPlaylist,
@@ -203,44 +213,52 @@ export namespace ServerPlayoutAdLibAPI {
 		baselineAdLibPieceId: PieceId,
 		queue: boolean
 	) {
-		return rundownPlaylistSyncFunction(rundownPlaylist._id, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			logger.debug('rundownBaselineAdLibPieceStart')
+		return rundownPlaylistSyncFunction(
+			rundownPlaylist._id,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'rundownBaselineAdLibPieceStart',
+			() => {
+				logger.debug('rundownBaselineAdLibPieceStart')
 
-			if (!rundownPlaylist.active)
-				throw new Meteor.Error(403, `Rundown Baseline AdLib-pieces can be only placed in an active rundown!`)
-			if (
-				rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
-				rundownPlaylist.holdState === RundownHoldState.PENDING
-			) {
-				throw new Meteor.Error(403, `Part AdLib-pieces can not be used in combination with hold!`)
+				if (!rundownPlaylist.active)
+					throw new Meteor.Error(
+						403,
+						`Rundown Baseline AdLib-pieces can be only placed in an active rundown!`
+					)
+				if (
+					rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
+					rundownPlaylist.holdState === RundownHoldState.PENDING
+				) {
+					throw new Meteor.Error(403, `Part AdLib-pieces can not be used in combination with hold!`)
+				}
+				const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
+
+				const partInstance = cache.PartInstances.findOne(partInstanceId)
+				if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
+				const rundown = cache.Rundowns.findOne(partInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
+				if (rundown.playlistId !== rundownPlaylist._id)
+					throw new Meteor.Error(
+						406,
+						`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylist._id}!"`
+					)
+
+				const adLibPiece = waitForPromise(cache.activationCache.getRundownBaselineAdLibPieces(rundown)).find(
+					(adlib) => adlib._id === baselineAdLibPieceId
+				)
+				if (!adLibPiece)
+					throw new Meteor.Error(404, `Rundown Baseline Ad Lib Item "${baselineAdLibPieceId}" not found!`)
+				if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
+					throw new Meteor.Error(
+						403,
+						`Rundown Baseline AdLib-pieces can be only placed in a currently playing part!`
+					)
+
+				innerStartOrQueueAdLibPiece(cache, rundownPlaylist, rundown, queue, partInstance, adLibPiece)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-			const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
-
-			const partInstance = cache.PartInstances.findOne(partInstanceId)
-			if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
-			const rundown = cache.Rundowns.findOne(partInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${partInstance.rundownId}" not found!`)
-			if (rundown.playlistId !== rundownPlaylist._id)
-				throw new Meteor.Error(
-					406,
-					`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylist._id}!"`
-				)
-
-			const adLibPiece = waitForPromise(cache.activationCache.getRundownBaselineAdLibPieces(rundown)).find(
-				(adlib) => adlib._id === baselineAdLibPieceId
-			)
-			if (!adLibPiece)
-				throw new Meteor.Error(404, `Rundown Baseline Ad Lib Item "${baselineAdLibPieceId}" not found!`)
-			if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
-				throw new Meteor.Error(
-					403,
-					`Rundown Baseline AdLib-pieces can be only placed in a currently playing part!`
-				)
-
-			innerStartOrQueueAdLibPiece(cache, rundownPlaylist, rundown, queue, partInstance, adLibPiece)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	function innerStartOrQueueAdLibPiece(
 		cache: CacheForRundownPlaylist,
@@ -294,47 +312,56 @@ export namespace ServerPlayoutAdLibAPI {
 	}
 
 	export function sourceLayerStickyPieceStart(rundownPlaylist: RundownPlaylist, sourceLayerId: string) {
-		return rundownPlaylistSyncFunction(rundownPlaylist._id, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const playlist = RundownPlaylists.findOne(rundownPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown "${rundownPlaylist._id}" not found!`)
-			if (!playlist.active) throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
-			if (!playlist.currentPartInstanceId)
-				throw new Meteor.Error(400, `A part needs to be active to place a sticky item`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylist._id,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'sourceLayerStickyPieceStart',
+			() => {
+				const playlist = RundownPlaylists.findOne(rundownPlaylist._id)
+				if (!playlist) throw new Meteor.Error(404, `Rundown "${rundownPlaylist._id}" not found!`)
+				if (!playlist.active)
+					throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
+				if (!playlist.currentPartInstanceId)
+					throw new Meteor.Error(400, `A part needs to be active to place a sticky item`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
 
-			const currentPartInstance = cache.PartInstances.findOne(playlist.currentPartInstanceId)
-			if (!currentPartInstance)
-				throw new Meteor.Error(
-					501,
-					`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
+				const currentPartInstance = cache.PartInstances.findOne(playlist.currentPartInstanceId)
+				if (!currentPartInstance)
+					throw new Meteor.Error(
+						501,
+						`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
+					)
+
+				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
+				if (!rundown)
+					throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
+
+				let showStyleBase = rundown.getShowStyleBase() // todo: database again
+
+				const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === sourceLayerId)
+				if (!sourceLayer) throw new Meteor.Error(404, `Source layer "${sourceLayerId}" not found!`)
+				if (!sourceLayer.isSticky)
+					throw new Meteor.Error(
+						400,
+						`Only sticky layers can be restarted. "${sourceLayerId}" is not sticky.`
+					)
+
+				const lastPieceInstance = innerFindLastPieceOnLayer(
+					cache,
+					playlist,
+					sourceLayer._id,
+					sourceLayer.stickyOriginalOnly || false
 				)
 
-			const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
-			if (!rundown)
-				throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
+				if (lastPieceInstance) {
+					const lastPiece = convertPieceToAdLibPiece(lastPieceInstance.piece)
+					innerStartOrQueueAdLibPiece(cache, playlist, rundown, false, currentPartInstance, lastPiece)
+				}
 
-			let showStyleBase = rundown.getShowStyleBase() // todo: database again
-
-			const sourceLayer = showStyleBase.sourceLayers.find((i) => i._id === sourceLayerId)
-			if (!sourceLayer) throw new Meteor.Error(404, `Source layer "${sourceLayerId}" not found!`)
-			if (!sourceLayer.isSticky)
-				throw new Meteor.Error(400, `Only sticky layers can be restarted. "${sourceLayerId}" is not sticky.`)
-
-			const lastPieceInstance = innerFindLastPieceOnLayer(
-				cache,
-				playlist,
-				sourceLayer._id,
-				sourceLayer.stickyOriginalOnly || false
-			)
-
-			if (lastPieceInstance) {
-				const lastPiece = convertPieceToAdLibPiece(lastPieceInstance.piece)
-				innerStartOrQueueAdLibPiece(cache, playlist, rundown, false, currentPartInstance, lastPiece)
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 
 	export function innerFindLastPieceOnLayer(
@@ -563,48 +590,53 @@ export namespace ServerPlayoutAdLibAPI {
 		const bucketAdlib = BucketAdLibs.findOne(bucketAdlibId)
 		if (!bucketAdlib) throw new Meteor.Error(404, `Bucket Adlib "${bucketAdlibId}" not found!`)
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const rundownPlaylist = RundownPlaylists.findOne(rundownPlaylistId)
-			if (!rundownPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-			if (!rundownPlaylist.active)
-				throw new Meteor.Error(403, `Bucket AdLib-pieces can be only placed in an active rundown!`)
-			if (!rundownPlaylist.currentPartInstanceId)
-				throw new Meteor.Error(400, `A part needs to be active to use a bucket adlib`)
-			if (
-				rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
-				rundownPlaylist.holdState === RundownHoldState.PENDING
-			) {
-				throw new Meteor.Error(403, `Buckete AdLib-pieces can not be used in combination with hold!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'startBucketAdlibPiece',
+			() => {
+				const rundownPlaylist = RundownPlaylists.findOne(rundownPlaylistId)
+				if (!rundownPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+				if (!rundownPlaylist.active)
+					throw new Meteor.Error(403, `Bucket AdLib-pieces can be only placed in an active rundown!`)
+				if (!rundownPlaylist.currentPartInstanceId)
+					throw new Meteor.Error(400, `A part needs to be active to use a bucket adlib`)
+				if (
+					rundownPlaylist.holdState === RundownHoldState.ACTIVE ||
+					rundownPlaylist.holdState === RundownHoldState.PENDING
+				) {
+					throw new Meteor.Error(403, `Buckete AdLib-pieces can not be used in combination with hold!`)
+				}
+
+				const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
+				if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
+					throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a currently playing part!`)
+
+				const currentPartInstance = cache.PartInstances.findOne(rundownPlaylist.currentPartInstanceId)
+				if (!currentPartInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
+				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(404, `Rundown "${currentPartInstance.rundownId}" not found!`)
+				if (rundown.playlistId !== rundownPlaylistId)
+					throw new Meteor.Error(
+						406,
+						`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylistId}!"`
+					)
+
+				if (
+					bucketAdlib.showStyleVariantId !== rundown.showStyleVariantId ||
+					bucketAdlib.studioId !== rundown.studioId
+				) {
+					throw new Meteor.Error(
+						404,
+						`Bucket AdLib "${bucketAdlibId}" is not compatible with rundown "${rundown._id}"!`
+					)
+				}
+
+				const newPieceInstance = convertAdLibToPieceInstance(bucketAdlib, currentPartInstance, queue)
+				innerStartAdLibPiece(cache, rundownPlaylist, rundown, currentPartInstance, newPieceInstance)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			const cache = waitForPromise(initCacheForRundownPlaylist(rundownPlaylist))
-			if (!queue && rundownPlaylist.currentPartInstanceId !== partInstanceId)
-				throw new Meteor.Error(403, `Part AdLib-pieces can be only placed in a currently playing part!`)
-
-			const currentPartInstance = cache.PartInstances.findOne(rundownPlaylist.currentPartInstanceId)
-			if (!currentPartInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
-			const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${currentPartInstance.rundownId}" not found!`)
-			if (rundown.playlistId !== rundownPlaylistId)
-				throw new Meteor.Error(
-					406,
-					`Rundown "${rundown._id}" not a part of RundownPlaylist "${rundownPlaylistId}!"`
-				)
-
-			if (
-				bucketAdlib.showStyleVariantId !== rundown.showStyleVariantId ||
-				bucketAdlib.studioId !== rundown.studioId
-			) {
-				throw new Meteor.Error(
-					404,
-					`Bucket AdLib "${bucketAdlibId}" is not compatible with rundown "${rundown._id}"!`
-				)
-			}
-
-			const newPieceInstance = convertAdLibToPieceInstance(bucketAdlib, currentPartInstance, queue)
-			innerStartAdLibPiece(cache, rundownPlaylist, rundown, currentPartInstance, newPieceInstance)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 }

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -94,56 +94,68 @@ export namespace ServerPlayoutAPI {
 	 * To be triggered well before the broadcast, since it may take time and cause outputs to flicker
 	 */
 	export function prepareRundownPlaylistForBroadcast(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'prepareRundownPlaylistForBroadcast',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 
-			if (dbPlaylist.active)
-				throw new Meteor.Error(404, `rundownPrepareForBroadcast cannot be run on an active rundown!`)
+				if (dbPlaylist.active)
+					throw new Meteor.Error(404, `rundownPrepareForBroadcast cannot be run on an active rundown!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
-			if (anyOtherActiveRundowns.length) {
-				// logger.warn('Only one rundown can be active at the same time. Active rundowns: ' + _.map(anyOtherActiveRundowns, rundown => rundown._id))
-				throw new Meteor.Error(
-					409,
-					'Only one rundown can be active at the same time. Active rundowns: ' +
-						_.map(anyOtherActiveRundowns, (rundown) => rundown._id)
-				)
+				const anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
+				if (anyOtherActiveRundowns.length) {
+					// logger.warn('Only one rundown can be active at the same time. Active rundowns: ' + _.map(anyOtherActiveRundowns, rundown => rundown._id))
+					throw new Meteor.Error(
+						409,
+						'Only one rundown can be active at the same time. Active rundowns: ' +
+							_.map(anyOtherActiveRundowns, (rundown) => rundown._id)
+					)
+				}
+
+				libResetRundownPlaylist(cache, playlist)
+				prepareStudioForBroadcast(true, playlist)
+
+				libActivateRundownPlaylist(cache, playlist, true) // Activate rundownPlaylist (rehearsal)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			libResetRundownPlaylist(cache, playlist)
-			prepareStudioForBroadcast(true, playlist)
-
-			libActivateRundownPlaylist(cache, playlist, true) // Activate rundownPlaylist (rehearsal)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	/**
 	 * Reset the broadcast, to be used during testing.
 	 * The User might have run through the rundown and wants to start over and try again
 	 */
 	export function resetRundownPlaylist(context: MethodContext, rundownPlaylistId: RundownPlaylistId): void {
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-			if (!dbPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-			if (dbPlaylist.active && !dbPlaylist.rehearsal && !Settings.allowRundownResetOnAir)
-				throw new Meteor.Error(401, `resetRundown can only be run in rehearsal!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'resetRundownPlaylist',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+				if (!dbPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+				if (dbPlaylist.active && !dbPlaylist.rehearsal && !Settings.allowRundownResetOnAir)
+					throw new Meteor.Error(401, `resetRundown can only be run in rehearsal!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			libResetRundownPlaylist(cache, playlist)
+				libResetRundownPlaylist(cache, playlist)
 
-			updateTimeline(cache, playlist.studioId)
+				updateTimeline(cache, playlist.studioId)
 
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 	/**
 	 * Activate the rundown, final preparations before going on air
@@ -154,23 +166,29 @@ export namespace ServerPlayoutAPI {
 		rundownPlaylistId: RundownPlaylistId,
 		rehearsal?: boolean
 	) {
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-			if (!dbPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-			if (dbPlaylist.active && !dbPlaylist.rehearsal && !Settings.allowRundownResetOnAir)
-				throw new Meteor.Error(402, `resetAndActivateRundownPlaylist cannot be run when active!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'resetAndActivateRundownPlaylist',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+				if (!dbPlaylist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+				if (dbPlaylist.active && !dbPlaylist.rehearsal && !Settings.allowRundownResetOnAir)
+					throw new Meteor.Error(402, `resetAndActivateRundownPlaylist cannot be run when active!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
 
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			libResetRundownPlaylist(cache, playlist)
-			prepareStudioForBroadcast(true, playlist)
+				libResetRundownPlaylist(cache, playlist)
+				prepareStudioForBroadcast(true, playlist)
 
-			libActivateRundownPlaylist(cache, playlist, !!rehearsal) // Activate rundown
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				libActivateRundownPlaylist(cache, playlist, !!rehearsal) // Activate rundown
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 	/**
 	 * Activate the rundownPlaylist, decativate any other running rundowns
@@ -181,41 +199,47 @@ export namespace ServerPlayoutAPI {
 		rehearsal: boolean
 	) {
 		check(rehearsal, Boolean)
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'forceResetAndActivateRundownPlaylist',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			let anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
-			let error: any
-			_.each(anyOtherActiveRundowns, (otherRundownPlaylist) => {
-				try {
-					deactivateRundownPlaylistInner(cache, otherRundownPlaylist)
-				} catch (e) {
-					error = e
+				let anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
+				let error: any
+				_.each(anyOtherActiveRundowns, (otherRundownPlaylist) => {
+					try {
+						deactivateRundownPlaylistInner(cache, otherRundownPlaylist)
+					} catch (e) {
+						error = e
+					}
+				})
+				if (error) {
+					// Ok, something went wrong, but check if the active rundowns where deactivated?
+					anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
+					if (anyOtherActiveRundowns.length) {
+						// No they weren't, we can't continue..
+						throw error
+					} else {
+						// They where deactivated, log the error and continue
+						logger.error(error)
+					}
 				}
-			})
-			if (error) {
-				// Ok, something went wrong, but check if the active rundowns where deactivated?
-				anyOtherActiveRundowns = getActiveRundownPlaylistsInStudio(cache, playlist.studioId, playlist._id)
-				if (anyOtherActiveRundowns.length) {
-					// No they weren't, we can't continue..
-					throw error
-				} else {
-					// They where deactivated, log the error and continue
-					logger.error(error)
-				}
+
+				libResetRundownPlaylist(cache, playlist)
+				prepareStudioForBroadcast(true, playlist)
+
+				libActivateRundownPlaylist(cache, playlist, rehearsal)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			libResetRundownPlaylist(cache, playlist)
-			prepareStudioForBroadcast(true, playlist)
-
-			libActivateRundownPlaylist(cache, playlist, rehearsal)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	/**
 	 * Only activate the rundown, don't reset anything
@@ -228,34 +252,46 @@ export namespace ServerPlayoutAPI {
 		// @TODO Check for a better solution to validate security methods
 		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 		check(rehearsal, Boolean)
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'activateRundownPlaylist',
+			() => {
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			prepareStudioForBroadcast(true, playlist)
+				prepareStudioForBroadcast(true, playlist)
 
-			libActivateRundownPlaylist(cache, playlist, rehearsal)
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				libActivateRundownPlaylist(cache, playlist, rehearsal)
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 	/**
 	 * Deactivate the rundown
 	 */
 	export function deactivateRundownPlaylist(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'deactivateRundownPlaylist',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			standDownStudio(cache, getStudioFromCache(cache, playlist), true)
-			libDeactivateRundownPlaylist(cache, playlist)
+				standDownStudio(cache, getStudioFromCache(cache, playlist), true)
+				libDeactivateRundownPlaylist(cache, playlist)
 
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 	/**
 	 * Trigger a reload of data of the rundown
@@ -265,26 +301,32 @@ export namespace ServerPlayoutAPI {
 		// @TODO Check for a better solution to validate security methods
 		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 		check(rundownPlaylistId, String)
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_INGEST, () => {
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_INGEST,
+			'reloadRundownPlaylistData',
+			() => {
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const rundowns = getRundownsFromCache(cache, playlist)
-			const response: ReloadRundownPlaylistResponse = {
-				rundownsResponses: rundowns.map((rundown) => {
-					return {
-						rundownId: rundown._id,
-						response: IngestActions.reloadRundown(rundown),
-					}
-				}),
+				const rundowns = getRundownsFromCache(cache, playlist)
+				const response: ReloadRundownPlaylistResponse = {
+					rundownsResponses: rundowns.map((rundown) => {
+						return {
+							rundownId: rundown._id,
+							response: IngestActions.reloadRundown(rundown),
+						}
+					}),
+				}
+
+				waitForPromise(cache.saveAllToDatabase())
+
+				return response
 			}
-
-			waitForPromise(cache.saveAllToDatabase())
-
-			return response
-		})
+		)
 	}
 	/**
 	 * Take the currently Next:ed Part (start playing it)
@@ -311,16 +353,22 @@ export namespace ServerPlayoutAPI {
 		check(rundownPlaylistId, String)
 		if (nextPartId) check(nextPartId, String)
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'setNextPart',
+			() => {
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			setNextPartInner(cache, playlist, nextPartId, setManually, nextTimeOffset)
+				setNextPartInner(cache, playlist, nextPartId, setManually, nextTimeOffset)
 
-			waitForPromise(cache.saveAllToDatabase())
-			return ClientAPI.responseSuccess(undefined)
-		})
+				waitForPromise(cache.saveAllToDatabase())
+				return ClientAPI.responseSuccess(undefined)
+			}
+		)
 	}
 
 	export function setNextPartInner(
@@ -365,18 +413,27 @@ export namespace ServerPlayoutAPI {
 		check(horizontalDelta, Number)
 		check(verticalDelta, Number)
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!horizontalDelta && !verticalDelta)
-				throw new Meteor.Error(402, `rundownMoveNext: invalid delta: (${horizontalDelta}, ${verticalDelta})`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'moveNextPart',
+			() => {
+				if (!horizontalDelta && !verticalDelta)
+					throw new Meteor.Error(
+						402,
+						`rundownMoveNext: invalid delta: (${horizontalDelta}, ${verticalDelta})`
+					)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const res = moveNextPartInner(cache, playlist, horizontalDelta, verticalDelta, setManually)
-			waitForPromise(cache.saveAllToDatabase())
-			return res
-		})
+				const res = moveNextPartInner(cache, playlist, horizontalDelta, verticalDelta, setManually)
+				waitForPromise(cache.saveAllToDatabase())
+				return res
+			}
+		)
 	}
 	function moveNextPartInner(
 		cache: CacheForRundownPlaylist,
@@ -480,39 +537,45 @@ export namespace ServerPlayoutAPI {
 		check(rundownPlaylistId, String)
 		if (nextSegmentId) check(nextSegmentId, String)
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
-			if (!dbPlaylist.active)
-				throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'setNextSegment',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+				if (!dbPlaylist.active)
+					throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			let nextSegment: Segment | null = null
-			if (nextSegmentId) {
-				nextSegment = cache.Segments.findOne(nextSegmentId) || null
+				let nextSegment: Segment | null = null
+				if (nextSegmentId) {
+					nextSegment = cache.Segments.findOne(nextSegmentId) || null
 
-				if (!nextSegment) throw new Meteor.Error(404, `Segment "${nextSegmentId}" not found!`)
-				const acceptableRundownIds = getRundownIDsFromCache(cache, playlist)
-				if (acceptableRundownIds.indexOf(nextSegment.rundownId) === -1) {
-					throw new Meteor.Error(
-						501,
-						`Segment "${nextSegmentId}" does not belong to Rundown Playlist "${rundownPlaylistId}"!`
-					)
+					if (!nextSegment) throw new Meteor.Error(404, `Segment "${nextSegmentId}" not found!`)
+					const acceptableRundownIds = getRundownIDsFromCache(cache, playlist)
+					if (acceptableRundownIds.indexOf(nextSegment.rundownId) === -1) {
+						throw new Meteor.Error(
+							501,
+							`Segment "${nextSegmentId}" does not belong to Rundown Playlist "${rundownPlaylistId}"!`
+						)
+					}
 				}
+
+				libSetNextSegment(cache, playlist, nextSegment)
+
+				// Update any future lookaheads
+				updateTimeline(cache, playlist.studioId)
+
+				waitForPromise(cache.saveAllToDatabase())
+
+				return ClientAPI.responseSuccess(undefined)
 			}
-
-			libSetNextSegment(cache, playlist, nextSegment)
-
-			// Update any future lookaheads
-			updateTimeline(cache, playlist.studioId)
-
-			waitForPromise(cache.saveAllToDatabase())
-
-			return ClientAPI.responseSuccess(undefined)
-		})
+		)
 	}
 	export function activateHold(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
 		// @TODO Check for a better solution to validate security methods
@@ -520,178 +583,196 @@ export namespace ServerPlayoutAPI {
 		check(rundownPlaylistId, String)
 		logger.debug('rundownActivateHold')
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!dbPlaylist.active)
-				throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'activateHold',
+			() => {
+				if (!dbPlaylist.active)
+					throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
 
-			if (!dbPlaylist.currentPartInstanceId)
-				throw new Meteor.Error(400, `Rundown Playlist "${rundownPlaylistId}" no current part!`)
-			if (!dbPlaylist.nextPartInstanceId)
-				throw new Meteor.Error(400, `Rundown Playlist "${rundownPlaylistId}" no next part!`)
+				if (!dbPlaylist.currentPartInstanceId)
+					throw new Meteor.Error(400, `Rundown Playlist "${rundownPlaylistId}" no current part!`)
+				if (!dbPlaylist.nextPartInstanceId)
+					throw new Meteor.Error(400, `Rundown Playlist "${rundownPlaylistId}" no next part!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
-			if (!currentPartInstance)
-				throw new Meteor.Error(404, `PartInstance "${playlist.currentPartInstanceId}" not found!`)
-			if (!nextPartInstance)
-				throw new Meteor.Error(404, `PartInstance "${playlist.nextPartInstanceId}" not found!`)
+				const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
+				if (!currentPartInstance)
+					throw new Meteor.Error(404, `PartInstance "${playlist.currentPartInstanceId}" not found!`)
+				if (!nextPartInstance)
+					throw new Meteor.Error(404, `PartInstance "${playlist.nextPartInstanceId}" not found!`)
 
-			if (playlist.holdState) {
-				throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" already doing a hold!`)
+				if (playlist.holdState) {
+					throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" already doing a hold!`)
+				}
+
+				if (
+					currentPartInstance.part.holdMode !== PartHoldMode.FROM ||
+					nextPartInstance.part.holdMode !== PartHoldMode.TO
+				) {
+					throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" incompatible pair of HoldMode!`)
+				}
+
+				cache.RundownPlaylists.update(rundownPlaylistId, { $set: { holdState: RundownHoldState.PENDING } })
+
+				updateTimeline(cache, playlist.studioId)
+
+				waitForPromise(cache.saveAllToDatabase())
 			}
-
-			if (
-				currentPartInstance.part.holdMode !== PartHoldMode.FROM ||
-				nextPartInstance.part.holdMode !== PartHoldMode.TO
-			) {
-				throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" incompatible pair of HoldMode!`)
-			}
-
-			cache.RundownPlaylists.update(rundownPlaylistId, { $set: { holdState: RundownHoldState.PENDING } })
-
-			updateTimeline(cache, playlist.studioId)
-
-			waitForPromise(cache.saveAllToDatabase())
-		})
+		)
 	}
 	export function deactivateHold(context: MethodContext, rundownPlaylistId: RundownPlaylistId) {
 		check(rundownPlaylistId, String)
 		logger.debug('deactivateHold')
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'deactivateHold',
+			() => {
+				const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 
-			if (dbPlaylist.holdState !== RundownHoldState.PENDING)
-				throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" is not pending a hold!`)
+				if (dbPlaylist.holdState !== RundownHoldState.PENDING)
+					throw new Meteor.Error(400, `RundownPlaylist "${rundownPlaylistId}" is not pending a hold!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			cache.RundownPlaylists.update(rundownPlaylistId, { $set: { holdState: RundownHoldState.NONE } })
+				cache.RundownPlaylists.update(rundownPlaylistId, { $set: { holdState: RundownHoldState.NONE } })
 
-			updateTimeline(cache, playlist.studioId)
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				updateTimeline(cache, playlist.studioId)
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 	export function disableNextPiece(context: MethodContext, rundownPlaylistId: RundownPlaylistId, undo?: boolean) {
 		// @TODO Check for a better solution to validate security methods
 		const dbPlaylist = checkAccessAndGetPlaylist(context, rundownPlaylistId)
 		check(rundownPlaylistId, String)
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!dbPlaylist.currentPartInstanceId) throw new Meteor.Error(401, `No current part!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'disableNextPiece',
+			() => {
+				if (!dbPlaylist.currentPartInstanceId) throw new Meteor.Error(401, `No current part!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id) as RundownPlaylist
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id) as RundownPlaylist
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
-			if (!currentPartInstance)
-				throw new Meteor.Error(404, `PartInstance "${playlist.currentPartInstanceId}" not found!`)
+				const { currentPartInstance, nextPartInstance } = getSelectedPartInstancesFromCache(cache, playlist)
+				if (!currentPartInstance)
+					throw new Meteor.Error(404, `PartInstance "${playlist.currentPartInstanceId}" not found!`)
 
-			const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(404, `Rundown "${currentPartInstance.rundownId}" not found!`)
-			const showStyleBase = rundown.getShowStyleBase()
+				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(404, `Rundown "${currentPartInstance.rundownId}" not found!`)
+				const showStyleBase = rundown.getShowStyleBase()
 
-			// @ts-ignore stringify
-			// logger.info(o)
-			// logger.info(JSON.stringify(o, '', 2))
+				// @ts-ignore stringify
+				// logger.info(o)
+				// logger.info(JSON.stringify(o, '', 2))
 
-			const allowedSourceLayers = normalizeArray(showStyleBase.sourceLayers, '_id')
+				const allowedSourceLayers = normalizeArray(showStyleBase.sourceLayers, '_id')
 
-			// logger.info('nowInPart', nowInPart)
-			// logger.info('filteredPieces', filteredPieces)
-			let getNextPiece = (partInstance: PartInstance, undo: boolean, ignoreStartedPlayback: boolean) => {
-				// Find next piece to disable
+				// logger.info('nowInPart', nowInPart)
+				// logger.info('filteredPieces', filteredPieces)
+				let getNextPiece = (partInstance: PartInstance, undo: boolean, ignoreStartedPlayback: boolean) => {
+					// Find next piece to disable
 
-				let nowInPart = 0
-				if (
-					!ignoreStartedPlayback &&
-					partInstance.part.startedPlayback &&
-					partInstance.part.timings &&
-					partInstance.part.timings.startedPlayback
-				) {
-					let lastStartedPlayback = _.last(partInstance.part.timings.startedPlayback)
+					let nowInPart = 0
+					if (
+						!ignoreStartedPlayback &&
+						partInstance.part.startedPlayback &&
+						partInstance.part.timings &&
+						partInstance.part.timings.startedPlayback
+					) {
+						let lastStartedPlayback = _.last(partInstance.part.timings.startedPlayback)
 
-					if (lastStartedPlayback) {
-						nowInPart = getCurrentTime() - lastStartedPlayback
+						if (lastStartedPlayback) {
+							nowInPart = getCurrentTime() - lastStartedPlayback
+						}
 					}
-				}
 
-				const pieceInstances = getAllPieceInstancesFromCache(cache, partInstance)
-				const sortedPieces: PieceInstance[] = sortPieceInstancesByStart(pieceInstances, nowInPart)
+					const pieceInstances = getAllPieceInstancesFromCache(cache, partInstance)
+					const sortedPieces: PieceInstance[] = sortPieceInstancesByStart(pieceInstances, nowInPart)
 
-				let findLast: boolean = !!undo
+					let findLast: boolean = !!undo
 
-				let filteredPieces = _.sortBy(
-					_.filter(sortedPieces, (piece: PieceInstance) => {
-						let sourceLayer = allowedSourceLayers[piece.piece.sourceLayerId]
-						if (
-							sourceLayer &&
-							sourceLayer.allowDisable &&
-							!piece.piece.virtual &&
-							!piece.piece.isTransition
-						)
-							return true
-						return false
-					}),
-					(piece: PieceInstance) => {
-						let sourceLayer = allowedSourceLayers[piece.piece.sourceLayerId]
-						return sourceLayer._rank || -9999
-					}
-				)
-				if (findLast) filteredPieces.reverse()
-
-				return filteredPieces.find((piece) => {
-					return (
-						piece.piece.enable.start >= nowInPart &&
-						((!undo && !piece.disabled) || (undo && piece.disabled))
+					let filteredPieces = _.sortBy(
+						_.filter(sortedPieces, (piece: PieceInstance) => {
+							let sourceLayer = allowedSourceLayers[piece.piece.sourceLayerId]
+							if (
+								sourceLayer &&
+								sourceLayer.allowDisable &&
+								!piece.piece.virtual &&
+								!piece.piece.isTransition
+							)
+								return true
+							return false
+						}),
+						(piece: PieceInstance) => {
+							let sourceLayer = allowedSourceLayers[piece.piece.sourceLayerId]
+							return sourceLayer._rank || -9999
+						}
 					)
-				})
-			}
+					if (findLast) filteredPieces.reverse()
 
-			if (nextPartInstance) {
-				// pretend that the next part never has played (even if it has)
-				nextPartInstance.part.startedPlayback = false
-			}
+					return filteredPieces.find((piece) => {
+						return (
+							piece.piece.enable.start >= nowInPart &&
+							((!undo && !piece.disabled) || (undo && piece.disabled))
+						)
+					})
+				}
 
-			const partInstances: Array<[PartInstance | undefined, boolean]> = [
-				[currentPartInstance, false],
-				[nextPartInstance, true], // If not found in currently playing part, let's look in the next one:
-			]
-			if (undo) partInstances.reverse()
+				if (nextPartInstance) {
+					// pretend that the next part never has played (even if it has)
+					nextPartInstance.part.startedPlayback = false
+				}
 
-			let nextPieceInstance: PieceInstance | undefined
+				const partInstances: Array<[PartInstance | undefined, boolean]> = [
+					[currentPartInstance, false],
+					[nextPartInstance, true], // If not found in currently playing part, let's look in the next one:
+				]
+				if (undo) partInstances.reverse()
 
-			for (const [partInstance, ignoreStartedPlayback] of partInstances) {
-				if (partInstance) {
-					nextPieceInstance = getNextPiece(partInstance, !!undo, ignoreStartedPlayback)
-					break
+				let nextPieceInstance: PieceInstance | undefined
+
+				for (const [partInstance, ignoreStartedPlayback] of partInstances) {
+					if (partInstance) {
+						nextPieceInstance = getNextPiece(partInstance, !!undo, ignoreStartedPlayback)
+						break
+					}
+				}
+
+				if (nextPieceInstance) {
+					logger.info((undo ? 'Disabling' : 'Enabling') + ' next PieceInstance ' + nextPieceInstance._id)
+					cache.PieceInstances.update(nextPieceInstance._id, {
+						$set: {
+							disabled: !undo,
+						},
+					})
+
+					updateTimeline(cache, playlist.studioId)
+
+					waitForPromise(cache.saveAllToDatabase())
+				} else {
+					throw new Meteor.Error(500, 'Found no future pieces')
 				}
 			}
-
-			if (nextPieceInstance) {
-				logger.info((undo ? 'Disabling' : 'Enabling') + ' next PieceInstance ' + nextPieceInstance._id)
-				cache.PieceInstances.update(nextPieceInstance._id, {
-					$set: {
-						disabled: !undo,
-					},
-				})
-
-				updateTimeline(cache, playlist.studioId)
-
-				waitForPromise(cache.saveAllToDatabase())
-			} else {
-				throw new Meteor.Error(500, 'Found no future pieces')
-			}
-		})
+		)
 	}
 	/**
 	 * Triggered from Playout-gateway when a Piece has started playing
@@ -709,34 +790,41 @@ export namespace ServerPlayoutAPI {
 
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.CALLBACK_PLAYOUT, () => {
-			const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
-			// This method is called when an auto-next event occurs
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.CALLBACK_PLAYOUT,
+			'onPiecePlaybackStarted',
+			() => {
+				const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
+				// This method is called when an auto-next event occurs
 
-			const pieceInstance = PieceInstances.findOne({
-				_id: pieceInstanceId,
-				rundownId: { $in: rundowns.map((r) => r._id) },
-			})
-			if (dynamicallyInserted && !pieceInstance) return // if it was dynamically inserted, it's okay if we can't find it
-			if (!pieceInstance)
-				throw new Meteor.Error(
-					404,
-					`PieceInstance "${pieceInstanceId}" in RundownPlaylist "${rundownPlaylistId}" not found!`
+				const pieceInstance = PieceInstances.findOne({
+					_id: pieceInstanceId,
+					rundownId: { $in: rundowns.map((r) => r._id) },
+				})
+				if (dynamicallyInserted && !pieceInstance) return // if it was dynamically inserted, it's okay if we can't find it
+				if (!pieceInstance)
+					throw new Meteor.Error(
+						404,
+						`PieceInstance "${pieceInstanceId}" in RundownPlaylist "${rundownPlaylistId}" not found!`
+					)
+
+				const isPlaying: boolean = !!(
+					pieceInstance.piece.startedPlayback && !pieceInstance.piece.stoppedPlayback
 				)
+				if (!isPlaying) {
+					logger.info(
+						`Playout reports pieceInstance "${pieceInstanceId}" has started playback on timestamp ${new Date(
+							startedPlayback
+						).toISOString()}`
+					)
 
-			const isPlaying: boolean = !!(pieceInstance.piece.startedPlayback && !pieceInstance.piece.stoppedPlayback)
-			if (!isPlaying) {
-				logger.info(
-					`Playout reports pieceInstance "${pieceInstanceId}" has started playback on timestamp ${new Date(
-						startedPlayback
-					).toISOString()}`
-				)
+					reportPieceHasStarted(rundownPlaylistId, pieceInstance, startedPlayback)
 
-				reportPieceHasStarted(rundownPlaylistId, pieceInstance, startedPlayback)
-
-				// We don't need to bother with an updateTimeline(), as this hasn't changed anything, but lets us accurately add started items when reevaluating
+					// We don't need to bother with an updateTimeline(), as this hasn't changed anything, but lets us accurately add started items when reevaluating
+				}
 			}
-		})
+		)
 	}
 	/**
 	 * Triggered from Playout-gateway when a Piece has stopped playing
@@ -754,32 +842,39 @@ export namespace ServerPlayoutAPI {
 
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.CALLBACK_PLAYOUT, () => {
-			const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.CALLBACK_PLAYOUT,
+			'onPiecePlaybackStopped',
+			() => {
+				const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
 
-			// This method is called when an auto-next event occurs
-			const pieceInstance = PieceInstances.findOne({
-				_id: pieceInstanceId,
-				rundownId: { $in: rundowns.map((r) => r._id) },
-			})
-			if (dynamicallyInserted && !pieceInstance) return // if it was dynamically inserted, it's okay if we can't find it
-			if (!pieceInstance)
-				throw new Meteor.Error(
-					404,
-					`PieceInstance "${pieceInstanceId}" in RundownPlaylist "${rundownPlaylistId}" not found!`
+				// This method is called when an auto-next event occurs
+				const pieceInstance = PieceInstances.findOne({
+					_id: pieceInstanceId,
+					rundownId: { $in: rundowns.map((r) => r._id) },
+				})
+				if (dynamicallyInserted && !pieceInstance) return // if it was dynamically inserted, it's okay if we can't find it
+				if (!pieceInstance)
+					throw new Meteor.Error(
+						404,
+						`PieceInstance "${pieceInstanceId}" in RundownPlaylist "${rundownPlaylistId}" not found!`
+					)
+
+				const isPlaying: boolean = !!(
+					pieceInstance.piece.startedPlayback && !pieceInstance.piece.stoppedPlayback
 				)
+				if (isPlaying) {
+					logger.info(
+						`Playout reports pieceInstance "${pieceInstanceId}" has stopped playback on timestamp ${new Date(
+							stoppedPlayback
+						).toISOString()}`
+					)
 
-			const isPlaying: boolean = !!(pieceInstance.piece.startedPlayback && !pieceInstance.piece.stoppedPlayback)
-			if (isPlaying) {
-				logger.info(
-					`Playout reports pieceInstance "${pieceInstanceId}" has stopped playback on timestamp ${new Date(
-						stoppedPlayback
-					).toISOString()}`
-				)
-
-				reportPieceHasStopped(rundownPlaylistId, pieceInstance, stoppedPlayback)
+					reportPieceHasStopped(rundownPlaylistId, pieceInstance, stoppedPlayback)
+				}
 			}
-		})
+		)
 	}
 	/**
 	 * Triggered from Playout-gateway when a Part has started playing
@@ -796,105 +891,84 @@ export namespace ServerPlayoutAPI {
 
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.CALLBACK_PLAYOUT, () => {
-			// This method is called when a part starts playing (like when an auto-next event occurs, or a manual next)
-			const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
+		return (
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.CALLBACK_PLAYOUT,
+			() => {
+				// This method is called when a part starts playing (like when an auto-next event occurs, or a manual next)
+				const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
 
-			const playingPartInstance = PartInstances.findOne({
-				_id: partInstanceId,
-				rundownId: { $in: rundowns.map((r) => r._id) },
-			})
+				const playingPartInstance = PartInstances.findOne({
+					_id: partInstanceId,
+					rundownId: { $in: rundowns.map((r) => r._id) },
+				})
 
-			if (playingPartInstance) {
-				// make sure we don't run multiple times, even if TSR calls us multiple times
+				if (playingPartInstance) {
+					// make sure we don't run multiple times, even if TSR calls us multiple times
 
-				const isPlaying = playingPartInstance.part.startedPlayback && !playingPartInstance.part.stoppedPlayback
-				if (!isPlaying) {
-					logger.info(
-						`Playout reports PartInstance "${partInstanceId}" has started playback on timestamp ${new Date(
-							startedPlayback
-						).toISOString()}`
-					)
-
-					let playlist = RundownPlaylists.findOne(rundownPlaylistId)
-					if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
-					if (!playlist.active)
-						throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
-
-					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
-					const rundown = cache.Rundowns.findOne(playingPartInstance.rundownId)
-					if (!rundown) throw new Meteor.Error(404, `Rundown "${playingPartInstance.rundownId}" not found!`)
-
-					playlist = cache.RundownPlaylists.findOne(playlist._id)
-					if (!playlist) throw new Meteor.Error(404, `Rundown Playlist not found in cache!`)
-
-					const { currentPartInstance, previousPartInstance } = getSelectedPartInstancesFromCache(
-						cache,
-						playlist
-					)
-
-					if (playlist.currentPartInstanceId === partInstanceId) {
-						// this is the current part, it has just started playback
-						if (playlist.previousPartInstanceId) {
-							if (!previousPartInstance) {
-								// We couldn't find the previous part: this is not a critical issue, but is clearly is a symptom of a larger issue
-								logger.error(
-									`Previous PartInstance "${playlist.previousPartInstanceId}" on RundownPlaylist "${playlist._id}" could not be found.`
-								)
-							} else if (!previousPartInstance.part.duration) {
-								onPartHasStoppedPlaying(cache, previousPartInstance, startedPlayback)
-							}
-						}
-
-						setRundownStartedPlayback(cache, playlist, rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
-
-						reportPartHasStarted(cache, playingPartInstance, startedPlayback)
-					} else if (playlist.nextPartInstanceId === partInstanceId) {
-						// this is the next part, clearly an autoNext has taken place
-						if (playlist.currentPartInstanceId) {
-							if (!currentPartInstance) {
-								// We couldn't find the previous part: this is not a critical issue, but is clearly is a symptom of a larger issue
-								logger.error(
-									`Previous PartInstance "${playlist.currentPartInstanceId}" on RundownPlaylist "${playlist._id}" could not be found.`
-								)
-							} else if (!currentPartInstance.part.duration) {
-								onPartHasStoppedPlaying(cache, currentPartInstance, startedPlayback)
-							}
-						}
-
-						setRundownStartedPlayback(cache, playlist, rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
-
-						cache.RundownPlaylists.update(playlist._id, {
-							$set: {
-								previousPartInstanceId: playlist.currentPartInstanceId,
-								currentPartInstanceId: playingPartInstance._id,
-								holdState: RundownHoldState.NONE,
-							},
-						})
-
-						reportPartHasStarted(cache, playingPartInstance, startedPlayback)
-
-						const nextPart = selectNextPart(
-							playlist,
-							playingPartInstance,
-							getAllOrderedPartsFromCache(cache, playlist)
+					const isPlaying =
+						playingPartInstance.part.startedPlayback && !playingPartInstance.part.stoppedPlayback
+					if (!isPlaying) {
+						logger.info(
+							`Playout reports PartInstance "${partInstanceId}" has started playback on timestamp ${new Date(
+								startedPlayback
+							).toISOString()}`
 						)
-						libsetNextPart(cache, playlist, nextPart ? nextPart.part : null)
-					} else {
-						// a part is being played that has not been selected for playback by Core
-						// show must go on, so find next part and update the Rundown, but log an error
-						const previousReported = playlist.lastIncorrectPartPlaybackReported
 
-						if (previousReported && Date.now() - previousReported > INCORRECT_PLAYING_PART_DEBOUNCE) {
-							// first time this has happened for a while, let's try to progress the show:
+						let playlist = RundownPlaylists.findOne(rundownPlaylistId)
+						if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found!`)
+						if (!playlist.active)
+							throw new Meteor.Error(501, `Rundown Playlist "${rundownPlaylistId}" is not active!`)
+
+						const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
+						const rundown = cache.Rundowns.findOne(playingPartInstance.rundownId)
+						if (!rundown)
+							throw new Meteor.Error(404, `Rundown "${playingPartInstance.rundownId}" not found!`)
+
+						playlist = cache.RundownPlaylists.findOne(playlist._id)
+						if (!playlist) throw new Meteor.Error(404, `Rundown Playlist not found in cache!`)
+
+						const { currentPartInstance, previousPartInstance } = getSelectedPartInstancesFromCache(
+							cache,
+							playlist
+						)
+
+						if (playlist.currentPartInstanceId === partInstanceId) {
+							// this is the current part, it has just started playback
+							if (playlist.previousPartInstanceId) {
+								if (!previousPartInstance) {
+									// We couldn't find the previous part: this is not a critical issue, but is clearly is a symptom of a larger issue
+									logger.error(
+										`Previous PartInstance "${playlist.previousPartInstanceId}" on RundownPlaylist "${playlist._id}" could not be found.`
+									)
+								} else if (!previousPartInstance.part.duration) {
+									onPartHasStoppedPlaying(cache, previousPartInstance, startedPlayback)
+								}
+							}
+
+							setRundownStartedPlayback(cache, playlist, rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
+
+							reportPartHasStarted(cache, playingPartInstance, startedPlayback)
+						} else if (playlist.nextPartInstanceId === partInstanceId) {
+							// this is the next part, clearly an autoNext has taken place
+							if (playlist.currentPartInstanceId) {
+								if (!currentPartInstance) {
+									// We couldn't find the previous part: this is not a critical issue, but is clearly is a symptom of a larger issue
+									logger.error(
+										`Previous PartInstance "${playlist.currentPartInstanceId}" on RundownPlaylist "${playlist._id}" could not be found.`
+									)
+								} else if (!currentPartInstance.part.duration) {
+									onPartHasStoppedPlaying(cache, currentPartInstance, startedPlayback)
+								}
+							}
 
 							setRundownStartedPlayback(cache, playlist, rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
 
 							cache.RundownPlaylists.update(playlist._id, {
 								$set: {
-									previousPartInstanceId: null,
+									previousPartInstanceId: playlist.currentPartInstanceId,
 									currentPartInstanceId: playingPartInstance._id,
-									lastIncorrectPartPlaybackReported: Date.now(), // save the time to prevent the system to go in a loop
+									holdState: RundownHoldState.NONE,
 								},
 							})
 
@@ -906,26 +980,53 @@ export namespace ServerPlayoutAPI {
 								getAllOrderedPartsFromCache(cache, playlist)
 							)
 							libsetNextPart(cache, playlist, nextPart ? nextPart.part : null)
+						} else {
+							// a part is being played that has not been selected for playback by Core
+							// show must go on, so find next part and update the Rundown, but log an error
+							const previousReported = playlist.lastIncorrectPartPlaybackReported
+
+							if (previousReported && Date.now() - previousReported > INCORRECT_PLAYING_PART_DEBOUNCE) {
+								// first time this has happened for a while, let's try to progress the show:
+
+								setRundownStartedPlayback(cache, playlist, rundown, startedPlayback) // Set startedPlayback on the rundown if this is the first item to be played
+
+								cache.RundownPlaylists.update(playlist._id, {
+									$set: {
+										previousPartInstanceId: null,
+										currentPartInstanceId: playingPartInstance._id,
+										lastIncorrectPartPlaybackReported: Date.now(), // save the time to prevent the system to go in a loop
+									},
+								})
+
+								reportPartHasStarted(cache, playingPartInstance, startedPlayback)
+
+								const nextPart = selectNextPart(
+									playlist,
+									playingPartInstance,
+									getAllOrderedPartsFromCache(cache, playlist)
+								)
+								libsetNextPart(cache, playlist, nextPart ? nextPart.part : null)
+							}
+
+							// TODO - should this even change the next?
+							logger.error(
+								`PartInstance "${playingPartInstance._id}" has started playback by the playout gateway, but has not been selected for playback!`
+							)
 						}
 
-						// TODO - should this even change the next?
-						logger.error(
-							`PartInstance "${playingPartInstance._id}" has started playback by the playout gateway, but has not been selected for playback!`
-						)
+						// complete the take
+						afterTake(cache, rundown.studioId, playingPartInstance)
+
+						waitForPromise(cache.saveAllToDatabase())
 					}
-
-					// complete the take
-					afterTake(cache, rundown.studioId, playingPartInstance)
-
-					waitForPromise(cache.saveAllToDatabase())
+				} else {
+					throw new Meteor.Error(
+						404,
+						`PartInstance "${partInstanceId}" in RundownPlayst "${rundownPlaylistId}" not found!`
+					)
 				}
-			} else {
-				throw new Meteor.Error(
-					404,
-					`PartInstance "${partInstanceId}" in RundownPlayst "${rundownPlaylistId}" not found!`
-				)
 			}
-		})
+		)
 	}
 	/**
 	 * Triggered from Playout-gateway when a Part has stopped playing
@@ -942,35 +1043,39 @@ export namespace ServerPlayoutAPI {
 
 		triggerWriteAccessBecauseNoCheckNecessary() // tmp
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.CALLBACK_PLAYOUT, () => {
-			// This method is called when a part stops playing (like when an auto-next event occurs, or a manual next)
-			const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
+		return (
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.CALLBACK_PLAYOUT,
+			() => {
+				// This method is called when a part stops playing (like when an auto-next event occurs, or a manual next)
+				const rundowns = Rundowns.find({ playlistId: rundownPlaylistId }).fetch()
 
-			const partInstance = PartInstances.findOne({
-				_id: partInstanceId,
-				rundownId: { $in: rundowns.map((r) => r._id) },
-			})
+				const partInstance = PartInstances.findOne({
+					_id: partInstanceId,
+					rundownId: { $in: rundowns.map((r) => r._id) },
+				})
 
-			if (partInstance) {
-				// make sure we don't run multiple times, even if TSR calls us multiple times
+				if (partInstance) {
+					// make sure we don't run multiple times, even if TSR calls us multiple times
 
-				const isPlaying = partInstance.part.startedPlayback && !partInstance.part.stoppedPlayback
-				if (isPlaying) {
-					logger.info(
-						`Playout reports PartInstance "${partInstanceId}" has stopped playback on timestamp ${new Date(
-							stoppedPlayback
-						).toISOString()}`
+					const isPlaying = partInstance.part.startedPlayback && !partInstance.part.stoppedPlayback
+					if (isPlaying) {
+						logger.info(
+							`Playout reports PartInstance "${partInstanceId}" has stopped playback on timestamp ${new Date(
+								stoppedPlayback
+							).toISOString()}`
+						)
+
+						reportPartHasStopped(rundownPlaylistId, partInstance, stoppedPlayback)
+					}
+				} else {
+					throw new Meteor.Error(
+						404,
+						`PartInstance "${partInstanceId}" in RundownPlayst "${rundownPlaylistId}" not found!`
 					)
-
-					reportPartHasStopped(rundownPlaylistId, partInstance, stoppedPlayback)
 				}
-			} else {
-				throw new Meteor.Error(
-					404,
-					`PartInstance "${partInstanceId}" in RundownPlayst "${rundownPlaylistId}" not found!`
-				)
 			}
-		})
+		)
 	}
 	/**
 	 * Make a copy of a piece and start playing it now
@@ -1074,65 +1179,71 @@ export namespace ServerPlayoutAPI {
 	) {
 		const now = getCurrentTime()
 
-		rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			const tmpPlaylist = RundownPlaylists.findOne(rundownPlaylistId)
-			if (!tmpPlaylist) throw new Meteor.Error(404, `Rundown "${rundownPlaylistId}" not found!`)
-			if (!tmpPlaylist.active) throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
-			if (!tmpPlaylist.currentPartInstanceId)
-				throw new Meteor.Error(400, `A part needs to be active to execute an action`)
+		rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'executeActionInner',
+			() => {
+				const tmpPlaylist = RundownPlaylists.findOne(rundownPlaylistId)
+				if (!tmpPlaylist) throw new Meteor.Error(404, `Rundown "${rundownPlaylistId}" not found!`)
+				if (!tmpPlaylist.active)
+					throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
+				if (!tmpPlaylist.currentPartInstanceId)
+					throw new Meteor.Error(400, `A part needs to be active to execute an action`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(tmpPlaylist))
-			const playlist = cache.RundownPlaylists.findOne(rundownPlaylistId)
-			if (!playlist) throw new Meteor.Error(404, `Rundown "${rundownPlaylistId}" not found!`)
+				const cache = waitForPromise(initCacheForRundownPlaylist(tmpPlaylist))
+				const playlist = cache.RundownPlaylists.findOne(rundownPlaylistId)
+				if (!playlist) throw new Meteor.Error(404, `Rundown "${rundownPlaylistId}" not found!`)
 
-			const studio = cache.activationCache.getStudio()
-			if (!studio) throw new Meteor.Error(501, `Current Studio "${playlist.studioId}" could not be found`)
+				const studio = cache.activationCache.getStudio()
+				if (!studio) throw new Meteor.Error(501, `Current Studio "${playlist.studioId}" could not be found`)
 
-			const currentPartInstance = playlist.currentPartInstanceId
-				? cache.PartInstances.findOne(playlist.currentPartInstanceId)
-				: undefined
-			if (!currentPartInstance)
-				throw new Meteor.Error(
-					501,
-					`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
+				const currentPartInstance = playlist.currentPartInstanceId
+					? cache.PartInstances.findOne(playlist.currentPartInstanceId)
+					: undefined
+				if (!currentPartInstance)
+					throw new Meteor.Error(
+						501,
+						`Current PartInstance "${playlist.currentPartInstanceId}" could not be found.`
+					)
+
+				const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
+				if (!rundown)
+					throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
+
+				const notesContext = new NotesContext(
+					`${rundown.name}(${playlist.name})`,
+					`playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
+						currentPartInstance._id
+					},execution=${getRandomId()}`,
+					false
 				)
+				const actionContext = new ActionExecutionContext(cache, notesContext, studio, playlist, rundown)
 
-			const rundown = cache.Rundowns.findOne(currentPartInstance.rundownId)
-			if (!rundown)
-				throw new Meteor.Error(501, `Current Rundown "${currentPartInstance.rundownId}" could not be found`)
+				// If any action cannot be done due to timings, that needs to be rejected by the context
+				func(actionContext, cache, rundown, currentPartInstance)
 
-			const notesContext = new NotesContext(
-				`${rundown.name}(${playlist.name})`,
-				`playlist=${playlist._id},rundown=${rundown._id},currentPartInstance=${
-					currentPartInstance._id
-				},execution=${getRandomId()}`,
-				false
-			)
-			const actionContext = new ActionExecutionContext(cache, notesContext, studio, playlist, rundown)
-
-			// If any action cannot be done due to timings, that needs to be rejected by the context
-			func(actionContext, cache, rundown, currentPartInstance)
-
-			if (
-				actionContext.currentPartState !== ActionPartChange.NONE ||
-				actionContext.nextPartState !== ActionPartChange.NONE
-			) {
-				syncPlayheadInfinitesForNextPartInstance(cache, playlist)
-			}
-
-			if (actionContext.takeAfterExecute) {
-				return ServerPlayoutAPI.callTakeWithCache(context, rundownPlaylistId, now, cache)
-			} else {
 				if (
 					actionContext.currentPartState !== ActionPartChange.NONE ||
 					actionContext.nextPartState !== ActionPartChange.NONE
 				) {
-					updateTimeline(cache, playlist.studioId)
+					syncPlayheadInfinitesForNextPartInstance(cache, playlist)
 				}
 
-				waitForPromise(cache.saveAllToDatabase())
+				if (actionContext.takeAfterExecute) {
+					return ServerPlayoutAPI.callTakeWithCache(context, rundownPlaylistId, now, cache)
+				} else {
+					if (
+						actionContext.currentPartState !== ActionPartChange.NONE ||
+						actionContext.nextPartState !== ActionPartChange.NONE
+					) {
+						updateTimeline(cache, playlist.studioId)
+					}
+
+					waitForPromise(cache.saveAllToDatabase())
+				}
 			}
-		})
+		)
 	}
 	/**
 	 * This exists for the purpose of mocking this call for testing.
@@ -1162,41 +1273,49 @@ export namespace ServerPlayoutAPI {
 
 		if (sourceLayerIds.length === 0) return
 
-		return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-			if (!dbPlaylist.active) throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
-			if (dbPlaylist.currentPartInstanceId !== partInstanceId)
-				throw new Meteor.Error(403, `Pieces can be only manipulated in a current part!`)
+		return rundownPlaylistSyncFunction(
+			rundownPlaylistId,
+			RundownSyncFunctionPriority.USER_PLAYOUT,
+			'sourceLayerOnPartStop',
+			() => {
+				if (!dbPlaylist.active)
+					throw new Meteor.Error(403, `Pieces can be only manipulated in an active rundown!`)
+				if (dbPlaylist.currentPartInstanceId !== partInstanceId)
+					throw new Meteor.Error(403, `Pieces can be only manipulated in a current part!`)
 
-			const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
+				const cache = waitForPromise(initCacheForRundownPlaylist(dbPlaylist))
 
-			const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
-			if (!playlist) throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
+				const playlist = cache.RundownPlaylists.findOne(dbPlaylist._id)
+				if (!playlist)
+					throw new Meteor.Error(404, `Rundown Playlist "${rundownPlaylistId}" not found in cache!`)
 
-			const partInstance = cache.PartInstances.findOne(partInstanceId)
-			if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
-			const lastStartedPlayback = partInstance.part.getLastStartedPlayback()
-			if (!lastStartedPlayback) throw new Meteor.Error(405, `Part "${partInstanceId}" has yet to start playback!`)
+				const partInstance = cache.PartInstances.findOne(partInstanceId)
+				if (!partInstance) throw new Meteor.Error(404, `PartInstance "${partInstanceId}" not found!`)
+				const lastStartedPlayback = partInstance.part.getLastStartedPlayback()
+				if (!lastStartedPlayback)
+					throw new Meteor.Error(405, `Part "${partInstanceId}" has yet to start playback!`)
 
-			const rundown = cache.Rundowns.findOne(partInstance.rundownId)
-			if (!rundown) throw new Meteor.Error(501, `Rundown "${partInstance.rundownId}" not found!`)
+				const rundown = cache.Rundowns.findOne(partInstance.rundownId)
+				if (!rundown) throw new Meteor.Error(501, `Rundown "${partInstance.rundownId}" not found!`)
 
-			const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId)
-			if (!showStyleBase) throw new Meteor.Error(404, `ShowStyleBase "${rundown.showStyleBaseId}" not found!`)
+				const showStyleBase = ShowStyleBases.findOne(rundown.showStyleBaseId)
+				if (!showStyleBase) throw new Meteor.Error(404, `ShowStyleBase "${rundown.showStyleBaseId}" not found!`)
 
-			ServerPlayoutAdLibAPI.innerStopPieces(
-				cache,
-				showStyleBase,
-				partInstance,
-				(pieceInstance) => sourceLayerIds.indexOf(pieceInstance.piece.sourceLayerId) !== -1,
-				undefined
-			)
+				ServerPlayoutAdLibAPI.innerStopPieces(
+					cache,
+					showStyleBase,
+					partInstance,
+					(pieceInstance) => sourceLayerIds.indexOf(pieceInstance.piece.sourceLayerId) !== -1,
+					undefined
+				)
 
-			syncPlayheadInfinitesForNextPartInstance(cache, playlist)
+				syncPlayheadInfinitesForNextPartInstance(cache, playlist)
 
-			updateTimeline(cache, playlist.studioId)
+				updateTimeline(cache, playlist.studioId)
 
-			waitForPromise(cache.saveAllToDatabase())
-		})
+				waitForPromise(cache.saveAllToDatabase())
+			}
+		)
 	}
 
 	export function updateStudioBaseline(context: MethodContext, studioId: StudioId) {
@@ -1239,8 +1358,12 @@ export namespace ServerPlayoutAPI {
 		const activeRundowns = getActiveRundownPlaylistsInStudio(cache, studio._id)
 
 		if (activeRundowns.length === 0) {
-			const markerId: TimelineObjId = protectString(`${studio._id}_baseline_version`)
-			const markerObject = cache.Timeline.findOne(markerId)
+			// const markerId: TimelineObjId = protectString(`${studio._id}_baseline_version`)
+			const studioTimeline = cache.Timeline.findOne(studioId)
+			if (!studioTimeline) return 'noBaseline'
+			const markerObject = studioTimeline.timeline.find(
+				(x) => x._id === protectString(`${studio._id}_baseline_version`)
+			)
 			if (!markerObject) return 'noBaseline'
 
 			const versionsContent = (markerObject.metaData || {}).versions || {}
@@ -1284,21 +1407,26 @@ export function triggerUpdateTimelineAfterIngestData(playlistId: RundownPlaylist
 
 	data.timeout = Meteor.setTimeout(() => {
 		if (updateTimelineFromIngestDataTimeouts.delete(playlistId)) {
-			return rundownPlaylistSyncFunction(playlistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-				const playlist = RundownPlaylists.findOne(playlistId)
-				if (!playlist) {
-					throw new Meteor.Error(404, `RundownPlaylist "${playlistId}" not found!`)
+			return rundownPlaylistSyncFunction(
+				playlistId,
+				RundownSyncFunctionPriority.USER_PLAYOUT,
+				'triggerUpdateTimelineAfterIngestData',
+				() => {
+					const playlist = RundownPlaylists.findOne(playlistId)
+					if (!playlist) {
+						throw new Meteor.Error(404, `RundownPlaylist "${playlistId}" not found!`)
+					}
+
+					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
+
+					if (playlist.active && playlist.currentPartInstanceId) {
+						// If the playlist is active, then updateTimeline as lookahead could have been affected
+						updateTimeline(cache, playlist.studioId)
+					}
+
+					waitForPromise(cache.saveAllToDatabase())
 				}
-
-				const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
-
-				if (playlist.active && playlist.currentPartInstanceId) {
-					// If the playlist is active, then updateTimeline as lookahead could have been affected
-					updateTimeline(cache, playlist.studioId)
-				}
-
-				waitForPromise(cache.saveAllToDatabase())
-			})
+			)
 		}
 	}, 1000)
 

--- a/meteor/server/api/playout/take.ts
+++ b/meteor/server/api/playout/take.ts
@@ -52,9 +52,14 @@ export function takeNextPartInner(
 ): ClientAPI.ClientResponse<void> {
 	let now = getCurrentTime()
 
-	return rundownPlaylistSyncFunction(rundownPlaylistId, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-		return takeNextPartInnerSync(context, rundownPlaylistId, now, existingCache)
-	})
+	return rundownPlaylistSyncFunction(
+		rundownPlaylistId,
+		RundownSyncFunctionPriority.USER_PLAYOUT,
+		'takeNextPartInner',
+		() => {
+			return takeNextPartInnerSync(context, rundownPlaylistId, now, existingCache)
+		}
+	)
 }
 
 /**

--- a/meteor/server/mockData/rundownData.ts
+++ b/meteor/server/mockData/rundownData.ts
@@ -89,14 +89,19 @@ if (!Settings.enableUserAccounts) {
 		debug_syncPlayheadInfinitesForNextPartInstance(id: RundownPlaylistId) {
 			logger.info(`syncPlayheadInfinitesForNextPartInstance ${id}`)
 
-			rundownPlaylistSyncFunction(id, RundownSyncFunctionPriority.USER_PLAYOUT, () => {
-				const playlist = RundownPlaylists.findOne(id)
-				if (!playlist) throw new Meteor.Error(404, 'not found')
+			rundownPlaylistSyncFunction(
+				id,
+				RundownSyncFunctionPriority.USER_PLAYOUT,
+				'debug_syncPlayheadInfinitesForNextPartInstance',
+				() => {
+					const playlist = RundownPlaylists.findOne(id)
+					if (!playlist) throw new Meteor.Error(404, 'not found')
 
-				const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
-				syncPlayheadInfinitesForNextPartInstance(cache, playlist)
-				waitForPromise(cache.saveAllToDatabase())
-			})
+					const cache = waitForPromise(initCacheForRundownPlaylist(playlist))
+					syncPlayheadInfinitesForNextPartInstance(cache, playlist)
+					waitForPromise(cache.saveAllToDatabase())
+				}
+			)
 		},
 
 		debug_forceClearAllActivationCaches() {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a performance issue related to updating ExpectedPlayoutItems, that is done in `updateExpectedPlayoutItemsOnRundown`, called at the end of the ingest methods.


* **What is the current behavior?** (You can also link to an open issue here)
`getAllPiecesFromCache` and `getAllAdLibPiecesFromCache`, performing `findFetch` on the cached collections, are executed for every Part, which makes the whole process extremely slow for long rundown because of the need for iterating over all the Pieces and AdlibPieces multiple times. O(m x n)


* **What is the new behavior (if this is a feature change)?**
Pieces and AdLibPieces are fetched and grouped by their `startPartId` or `partId`. O(n)

In addition: 

- One occurrence of uncached database access is removed (merge error)
- Context logging of is improved by passing a name to `rundownPlaylistSyncFunction`. As a side effect, it may lead to performance improvement under certain conditions, because before, anonymous functions passed to `rundownPlaylistSyncFunction` caused `getFunctionName` to do unnecessary work (including filesystem access).