### PR TITLE
Feat: next tally settings

### DIFF
--- a/meteor/client/ui/Settings/RundownLayoutEditor.tsx
+++ b/meteor/client/ui/Settings/RundownLayoutEditor.tsx
@@ -132,6 +132,8 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 						showThumbnailsInList: false,
 						hideDuplicates: false,
 						default: false,
+						nextInCurrentPart: false,
+						oneNextPerSourceLayer: false,
 					}),
 				},
 			})
@@ -788,6 +790,32 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 									<EditAttribute
 										modifiedClassName="bghl"
 										attribute={`filters.${index}.hideDuplicates`}
+										obj={item}
+										type="checkbox"
+										collection={RundownLayouts}
+										className="mod mas"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field" title="eg. when pieces in current part serve as data stores for adlibing">
+									{t('Current part can contain next pieces')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.nextInCurrentPart`}
+										obj={item}
+										type="checkbox"
+										collection={RundownLayouts}
+										className="mod mas"
+									/>
+								</label>
+							</div>
+							<div className="mod mvs mhs">
+								<label className="field">
+									{t('Indicate only one next piece per source layer')}
+									<EditAttribute
+										modifiedClassName="bghl"
+										attribute={`filters.${index}.oneNextPerSourceLayer`}
 										obj={item}
 										type="checkbox"
 										collection={RundownLayouts}

--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -77,6 +77,8 @@ export namespace RundownLayoutsAPI {
 			currentSegment: false,
 			showThumbnailsInList: false,
 			hideDuplicates: false,
+			nextInCurrentPart: false,
+			oneNextPerSourceLayer: false,
 		}
 	}
 }

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -107,6 +107,8 @@ export interface RundownLayoutFilterBase extends RundownLayoutElementBase {
 	showThumbnailsInList: boolean
 	hideDuplicates: boolean
 	currentSegment: boolean
+	nextInCurrentPart: boolean
+	oneNextPerSourceLayer: boolean
 	/**
 	 * true: include Rundown Baseline AdLib Pieces
 	 * false: do not include Rundown Baseline AdLib Pieces


### PR DESCRIPTION
Adds two properties to the DashboardPanel:

- _Current part can contain next pieces_ - makes custom tally behavior around finding next in current part (made specifically for the touch UI) optional
- _Indicate only one next piece per source layer_ - prevents double tally in most cases by limiting and prioritizing the pieces from the next part, if present