### PR TITLE
Fix: Potentially stuck next segment

### DIFF
--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -234,6 +234,8 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 			props.segmentId !== nextProps.segmentId ||
 			props.segmentRef !== nextProps.segmentRef ||
 			props.timeScale !== nextProps.timeScale ||
+			props.ownCurrentPartInstance !== nextProps.ownCurrentPartInstance ||
+			props.ownNextPartInstance !== nextProps.ownNextPartInstance ||
 			!equalSets(props.segmentsIdsBefore, nextProps.segmentsIdsBefore)
 		) {
 			return true


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Sometimes two segment might appear as next (green header). 


* **What is the new behavior (if this is a feature change)?**
Bug should be fixed by comparing `ownNextPartInstance` in tracker's `checkUpdate` because this prop might be updated
in other run of the tracker's autorun than `playlist.nextPartInstanceId` was, which could result in a segment keeping its next class after another segment is set as next.

<!--
* **Other information**:

**Status**

Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
-->