### PR TITLE
feat: add cron job routines to clean up part- and piece instances

### DIFF
--- a/meteor/lib/api/system.ts
+++ b/meteor/lib/api/system.ts
@@ -28,5 +28,6 @@ export interface SystemAPI {
 export enum SystemAPIMethods {
 	'cleanupIndexes' = 'system.cleanupIndexes',
 	'cleanupOldData' = 'system.cleanupOldData',
+	'runCronjob' = 'system.runCronjob',
 	'doSystemBenchmark' = 'system.doSystemBenchmark',
 }

--- a/meteor/lib/collections/PartInstances.ts
+++ b/meteor/lib/collections/PartInstances.ts
@@ -100,7 +100,10 @@ export class PartInstance implements DBPartInstance {
 			this[key] = document[key]
 		})
 		this.isTemporary = isTemporary === true
-		this.part = new Part(document.part)
+		if (document.part) {
+			// allows skipping the part field when fetching
+			this.part = new Part(document.part)
+		}
 	}
 }
 

--- a/meteor/server/api/system.ts
+++ b/meteor/server/api/system.ts
@@ -55,6 +55,7 @@ import { getActiveRundownPlaylistsInStudio } from './playout/studio'
 import { PieceInstances } from '../../lib/collections/PieceInstances'
 import { createMongoCollection } from '../../lib/collections/lib'
 import { PeripheralDeviceAPI } from '../../lib/api/peripheralDevice'
+import { nightlyCronjobInner } from '../cronjobs'
 
 function setupIndexes(removeOldIndexes: boolean = false): IndexSpecification[] {
 	// Note: This function should NOT run on Meteor.startup, due to getCollectionIndexes failing if run before indexes have been created.
@@ -485,6 +486,11 @@ export function cleanupOldData(
 
 	return cleanupOldDataInner(actuallyRemoveOldData)
 }
+export function runCronjob(context: MethodContext): void {
+	SystemWriteAccess.coreSystem(context)
+
+	return nightlyCronjobInner()
+}
 
 let mongoTest: TransformedCollection<any, any> | undefined = undefined
 /** Runs a set of system benchmarks, that are designed to test various aspects of the hardware-performance on the server */
@@ -741,6 +747,9 @@ class SystemAPIClass extends MethodContextAPI implements SystemAPI {
 	}
 	cleanupOldData(actuallyRemoveOldData: boolean) {
 		return makePromise(() => cleanupOldData(this, actuallyRemoveOldData))
+	}
+	runCronjob() {
+		return makePromise(() => runCronjob(this))
 	}
 	async doSystemBenchmark(runCount: number = 1) {
 		return doSystemBenchmark(this, runCount)

--- a/meteor/server/cronjobs.ts
+++ b/meteor/server/cronjobs.ts
@@ -14,6 +14,9 @@ import { CASPARCG_RESTART_TIME } from '../lib/constants'
 import { getCoreSystem } from '../lib/collections/CoreSystem'
 import { RundownPlaylists } from '../lib/collections/RundownPlaylists'
 import { internalStoreRundownPlaylistSnapshot } from './api/snapshot'
+import { PartInstances } from '../lib/collections/PartInstances'
+import { Parts } from '../lib/collections/Parts'
+import { PieceInstances } from '../lib/collections/PieceInstances'
 
 let lowPrioFcn = (fcn: (...args: any[]) => any, ...args: any[]) => {
 	// Do it at a random time in the future:
@@ -22,10 +25,173 @@ let lowPrioFcn = (fcn: (...args: any[]) => any, ...args: any[]) => {
 	}, Math.random() * 10 * 1000)
 }
 
-Meteor.startup(() => {
-	let lastNightlyCronjob = 0
-	let failedRetries = 0
+let lastNightlyCronjob = 0
+let failedRetries = 0
 
+export function nightlyCronjobInner() {
+	let previousLastNightlyCronjob = lastNightlyCronjob
+	lastNightlyCronjob = getCurrentTime()
+	logger.info('Nightly cronjob: starting...')
+	const system = getCoreSystem()
+
+	// Clean up Rundown data cache:
+	// Remove caches not related to rundowns:
+	let rundownCacheCount = 0
+	let rundownIds = _.map(Rundowns.find().fetch(), (rundown) => rundown._id)
+	IngestDataCache.find({
+		rundownId: { $nin: rundownIds },
+	}).forEach((roc) => {
+		lowPrioFcn(IngestDataCache.remove, roc._id)
+		rundownCacheCount++
+	})
+	if (rundownCacheCount) logger.info('Cronjob: Will remove cached data from ' + rundownCacheCount + ' rundowns')
+
+	const cleanLimitTime = getCurrentTime() - 1000 * 3600 * 24 * 50 // 50 days ago
+
+	// Remove old entries in AsRunLog:
+	const oldAsRunLogCount: number = AsRunLog.find({
+		timestamp: { $lt: cleanLimitTime },
+	}).count()
+	if (oldAsRunLogCount > 0) {
+		logger.info(`Cronjob: Will remove ${oldAsRunLogCount} entries from AsRunLog`)
+		lowPrioFcn(() => {
+			AsRunLog.remove({
+				timestamp: { $lt: cleanLimitTime },
+			})
+		})
+	}
+
+	// Remove old PartInstances and PieceInstances:
+	const getPartInstanceIdsToRemove = () => {
+		const existingPartIds = Parts.find({}, { fields: { _id: 1 } })
+			.fetch()
+			.map((part) => part._id)
+		const oldPartInstanceSelector = {
+			reset: true,
+			'timings.takeOut': { $lt: cleanLimitTime },
+			'part._id': { $nin: existingPartIds },
+		}
+		const oldPartInstanceIds = PartInstances.find(oldPartInstanceSelector, { fields: { _id: 1 } })
+			.fetch()
+			.map((partInstance) => partInstance._id)
+		return oldPartInstanceIds
+	}
+	const partInstanceIdsToRemove = getPartInstanceIdsToRemove()
+	if (partInstanceIdsToRemove.length > 0) {
+		logger.info(`Cronjob: Will remove ${partInstanceIdsToRemove.length} PartInstances`)
+	}
+	const oldPieceInstances = PieceInstances.find({
+		partInstanceId: { $in: partInstanceIdsToRemove },
+	}).count()
+	if (oldPieceInstances > 0) {
+		logger.info(`Cronjob: Will remove ${oldPieceInstances} PieceInstances`)
+	}
+	lowPrioFcn(() => {
+		const partInstanceIdsToRemove = getPartInstanceIdsToRemove()
+		PartInstances.remove({ _id: { $in: partInstanceIdsToRemove } })
+		PieceInstances.remove({
+			partInstanceId: { $in: partInstanceIdsToRemove },
+		})
+	})
+
+	// Remove old entries in UserActionsLog:
+	const oldUserActionsLogCount: number = UserActionsLog.find({
+		timestamp: { $lt: cleanLimitTime },
+	}).count()
+	if (oldUserActionsLogCount > 0) {
+		logger.info(`Cronjob: Will remove ${oldUserActionsLogCount} entries from UserActionsLog`)
+		lowPrioFcn(() => {
+			UserActionsLog.remove({
+				timestamp: { $lt: cleanLimitTime },
+			})
+		})
+	}
+
+	// Remove old entries in Snapshots:
+	const oldSnapshotsCount: number = Snapshots.find({
+		created: { $lt: cleanLimitTime },
+	}).count()
+	if (oldSnapshotsCount > 0) {
+		logger.info(`Cronjob: Will remove ${oldSnapshotsCount} entries from Snapshots`)
+		lowPrioFcn(() => {
+			Snapshots.remove({
+				created: { $lt: cleanLimitTime },
+			})
+		})
+	}
+
+	if (system?.cron?.storeRundownSnapshots?.enabled) {
+		let filter = system.cron.storeRundownSnapshots.rundownNames?.length
+			? { name: { $in: system.cron.storeRundownSnapshots.rundownNames } }
+			: {}
+
+		RundownPlaylists.find(filter).forEach((playlist) => {
+			lowPrioFcn(() => {
+				logger.info(`Cronjob: Will store snapshot for rundown playlist "${playlist._id}"`)
+				internalStoreRundownPlaylistSnapshot(null, playlist._id, 'Automatic, taken by cron job')
+			})
+		})
+	}
+
+	let ps: Array<Promise<any>> = []
+	// restart casparcg
+	if (!system?.cron?.casparCG?.disabled) {
+		PeripheralDevices.find({
+			type: PeripheralDeviceAPI.DeviceType.PLAYOUT,
+		}).forEach((device) => {
+			PeripheralDevices.find({
+				parentDeviceId: device._id,
+			}).forEach((subDevice) => {
+				if (
+					subDevice.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
+					subDevice.subType === TSR.DeviceType.CASPARCG
+				) {
+					logger.info('Cronjob: Trying to restart CasparCG on device "' + subDevice._id + '"')
+
+					ps.push(
+						new Promise((resolve, reject) => {
+							PeripheralDeviceAPI.executeFunctionWithCustomTimeout(
+								subDevice._id,
+								(err) => {
+									if (err) {
+										logger.error('Cronjob: "' + subDevice._id + '": CasparCG restart error', err)
+										if ((err + '').match(/timeout/i)) {
+											// If it was a timeout, maybe we could try again later?
+											if (failedRetries < 5) {
+												failedRetries++
+												lastNightlyCronjob = previousLastNightlyCronjob // try again later
+											}
+											resolve()
+										} else {
+											reject(err)
+										}
+									} else {
+										logger.info('Cronjob: "' + subDevice._id + '": CasparCG restart done')
+										resolve()
+									}
+								},
+								CASPARCG_RESTART_TIME,
+								'restartCasparCG'
+							)
+						})
+					)
+				}
+			})
+		})
+	}
+	Promise.all(ps)
+		.then(() => {
+			failedRetries = 0
+		})
+		.catch((err) => {
+			logger.error(err)
+		})
+
+	// last:
+	logger.info('Nightly cronjob: done')
+}
+
+Meteor.startup(() => {
 	function nightlyCronjob() {
 		let d = new Date(getCurrentTime())
 		let timeSinceLast = getCurrentTime() - lastNightlyCronjob
@@ -34,137 +200,7 @@ Meteor.startup(() => {
 			d.getHours() < 5 && // It is nighttime
 			timeSinceLast > 20 * 3600 * 1000 // was last run yesterday
 		) {
-			let previousLastNightlyCronjob = lastNightlyCronjob
-			lastNightlyCronjob = getCurrentTime()
-			logger.info('Nightly cronjob: starting...')
-			const system = getCoreSystem()
-
-			// Clean up Rundown data cache:
-			// Remove caches not related to rundowns:
-			let rundownCacheCount = 0
-			let rundownIds = _.map(Rundowns.find().fetch(), (rundown) => rundown._id)
-			IngestDataCache.find({
-				rundownId: { $nin: rundownIds },
-			}).forEach((roc) => {
-				lowPrioFcn(IngestDataCache.remove, roc._id)
-				rundownCacheCount++
-			})
-			if (rundownCacheCount)
-				logger.info('Cronjob: Will remove cached data from ' + rundownCacheCount + ' rundowns')
-
-			const cleanLimitTime = getCurrentTime() - 1000 * 3600 * 24 * 50 // 50 days ago
-
-			// Remove old entries in AsRunLog:
-			const oldAsRunLogCount: number = AsRunLog.find({
-				timestamp: { $lt: cleanLimitTime },
-			}).count()
-			if (oldAsRunLogCount > 0) {
-				logger.info(`Cronjob: Will remove ${oldAsRunLogCount} entries from AsRunLog`)
-				lowPrioFcn(() => {
-					AsRunLog.remove({
-						timestamp: { $lt: cleanLimitTime },
-					})
-				})
-			}
-
-			// Remove old entries in UserActionsLog:
-			const oldUserActionsLogCount: number = UserActionsLog.find({
-				timestamp: { $lt: cleanLimitTime },
-			}).count()
-			if (oldUserActionsLogCount > 0) {
-				logger.info(`Cronjob: Will remove ${oldUserActionsLogCount} entries from UserActionsLog`)
-				lowPrioFcn(() => {
-					UserActionsLog.remove({
-						timestamp: { $lt: cleanLimitTime },
-					})
-				})
-			}
-
-			// Remove old entries in Snapshots:
-			const oldSnapshotsCount: number = Snapshots.find({
-				created: { $lt: cleanLimitTime },
-			}).count()
-			if (oldSnapshotsCount > 0) {
-				logger.info(`Cronjob: Will remove ${oldSnapshotsCount} entries from Snapshots`)
-				lowPrioFcn(() => {
-					Snapshots.remove({
-						created: { $lt: cleanLimitTime },
-					})
-				})
-			}
-
-			if (system?.cron?.storeRundownSnapshots?.enabled) {
-				let filter = system.cron.storeRundownSnapshots.rundownNames?.length
-					? { name: { $in: system.cron.storeRundownSnapshots.rundownNames } }
-					: {}
-
-				RundownPlaylists.find(filter).forEach((playlist) => {
-					lowPrioFcn(() => {
-						logger.info(`Cronjob: Will store snapshot for rundown playlist "${playlist._id}"`)
-						internalStoreRundownPlaylistSnapshot(null, playlist._id, 'Automatic, taken by cron job')
-					})
-				})
-			}
-
-			let ps: Array<Promise<any>> = []
-			// restart casparcg
-			if (!system?.cron?.casparCG?.disabled) {
-				PeripheralDevices.find({
-					type: PeripheralDeviceAPI.DeviceType.PLAYOUT,
-				}).forEach((device) => {
-					PeripheralDevices.find({
-						parentDeviceId: device._id,
-					}).forEach((subDevice) => {
-						if (
-							subDevice.type === PeripheralDeviceAPI.DeviceType.PLAYOUT &&
-							subDevice.subType === TSR.DeviceType.CASPARCG
-						) {
-							logger.info('Cronjob: Trying to restart CasparCG on device "' + subDevice._id + '"')
-
-							ps.push(
-								new Promise((resolve, reject) => {
-									PeripheralDeviceAPI.executeFunctionWithCustomTimeout(
-										subDevice._id,
-										(err) => {
-											if (err) {
-												logger.error(
-													'Cronjob: "' + subDevice._id + '": CasparCG restart error',
-													err
-												)
-												if ((err + '').match(/timeout/i)) {
-													// If it was a timeout, maybe we could try again later?
-													if (failedRetries < 5) {
-														failedRetries++
-														lastNightlyCronjob = previousLastNightlyCronjob // try again later
-													}
-													resolve()
-												} else {
-													reject(err)
-												}
-											} else {
-												logger.info('Cronjob: "' + subDevice._id + '": CasparCG restart done')
-												resolve()
-											}
-										},
-										CASPARCG_RESTART_TIME,
-										'restartCasparCG'
-									)
-								})
-							)
-						}
-					})
-				})
-			}
-			Promise.all(ps)
-				.then(() => {
-					failedRetries = 0
-				})
-				.catch((err) => {
-					logger.error(err)
-				})
-
-			// last:
-			logger.info('Nightly cronjob: done')
+			nightlyCronjobInner()
 		}
 	}
 	Meteor.setInterval(nightlyCronjob, 5 * 60 * 1000) // check every 5 minutes


### PR DESCRIPTION
- remove reset partInstances that were taken out at least `cleanLimitTime` ms ago (50 days) and their part no longer exists
- remove pieceInstances of those partInstances
- add `runCronjob` SystemAPI method to trigger the cronjob routines on demand
