### PR TITLE
fix: Mini Shelf tweaks and fixes

### DIFF
--- a/meteor/client/styles/customInstallation.scss
+++ b/meteor/client/styles/customInstallation.scss
@@ -268,7 +268,7 @@ body.tv2 {
 		}
 	}
 	.rundown-view-shelf {
-		margin: 0.75em 1.5em 0.75em 2.5em;
+		margin: 1.5em 1.5em 1.5em 1.5em;
 		border-radius: 0;
 		box-shadow: unset;
 	}
@@ -286,7 +286,7 @@ body.tv2 {
 	.segment-timeline-wraper--shelf.segment-timeline-wraper--hidden
 		+ .segment-timeline-wraper--shelf.segment-timeline-wraper--hidden
 		.rundown-view-shelf.dashboard-panel {
-		margin-top: -0.5em;
+		margin-top: -1.5em;
 	}
 	.segment-timeline + .rundown-view-shelf {
 		margin: -0.25em 1.5em 0.75em 1.5em;

--- a/meteor/client/styles/shelf/dashboard-rundownView.scss
+++ b/meteor/client/styles/shelf/dashboard-rundownView.scss
@@ -5,8 +5,9 @@
 	margin: 1.5em;
 	padding: 0;
 	position: relative;
+	background: none;
+	border: none;
 
-	background: #161616;
 	-webkit-box-shadow: 7px 6px 20px 0px rgba(0, 0, 0, 0.7);
 	-moz-box-shadow: 7px 6px 20px 0px rgba(0, 0, 0, 0.7);
 	box-shadow: 7px 6px 20px 0px rgba(0, 0, 0, 0.7);
@@ -142,10 +143,4 @@
 .segment-timeline + .rundown-view-shelf {
 	padding: 5px;
 	padding-left: 12.5em;
-}
-
-.segment-timeline-wraper--hidden {
-	.rundown-view-shelf.dashboard-panel {
-		background: $segment-background-color;
-	}
 }

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -95,7 +95,7 @@ import { AdlibSegmentUi, fetchAndFilter, matchFilter, SourceLayerLookup } from '
 import { Settings } from '../../lib/Settings'
 import { PointerLockCursor } from '../lib/PointerLockCursor'
 import { documentTitle } from '../lib/DocumentTitleProvider'
-import { PartInstance } from '../../lib/collections/PartInstances'
+import { PartInstance, PartInstanceId } from '../../lib/collections/PartInstances'
 import { RundownDividerHeader } from './RundownView/RundownDividerHeader'
 import { CASPARCG_RESTART_TIME } from '../../lib/constants'
 import { memoizedIsolatedAutorun } from '../lib/reactiveData/reactiveDataHelper'
@@ -1336,6 +1336,8 @@ interface IState {
 	/** Tracks whether the user has resized the shelf to prevent using default shelf settings */
 	wasShelfResizedByUser: boolean
 	keyboardQueuedPiece: AdLibPieceUi | undefined
+	keyboardQueuedPartInstanceId: PartInstanceId | undefined
+	keyboardRequeue: boolean
 }
 
 type MatchedSegment = {
@@ -1638,6 +1640,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				currentRundown: undefined,
 				wasShelfResizedByUser: false,
 				keyboardQueuedPiece: undefined,
+				keyboardQueuedPartInstanceId: undefined,
+				keyboardRequeue: false,
 			}
 		}
 
@@ -2008,6 +2012,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			}
 			if (this.props.currentPartInstance?.segmentId !== prevProps.currentPartInstance?.segmentId) {
 				this.setState({ keyboardQueuedPiece: undefined })
+			} else if (this.props.playlist && prevProps.playlist && this.state.keyboardQueuedPartInstanceId) {
+				if (
+					(prevProps.playlist.currentPartInstanceId !== this.props.playlist.currentPartInstanceId &&
+						this.props.playlist.currentPartInstanceId !== this.state.keyboardQueuedPartInstanceId) ||
+					(prevProps.playlist.currentPartInstanceId === this.props.playlist.currentPartInstanceId &&
+						prevProps.playlist.nextPartInstanceId !== this.props.playlist.nextPartInstanceId &&
+						this.props.playlist.nextPartInstanceId !== this.state.keyboardQueuedPartInstanceId)
+				) {
+					this.setState({ keyboardRequeue: true, keyboardQueuedPartInstanceId: undefined })
+				}
 			}
 		}
 
@@ -2640,6 +2654,16 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			}
 		}
 
+		onPieceQueued = (err: any, res: { queuedPartInstanceId?: PartInstanceId; taken?: boolean }) => {
+			if (!err && res) {
+				if (res.taken) {
+					this.setState({ keyboardQueuedPartInstanceId: undefined })
+				} else {
+					this.setState({ keyboardQueuedPartInstanceId: res.queuedPartInstanceId })
+				}
+			}
+		}
+
 		queueAdLibPiece = (adlibPiece: AdLibPieceUi, e: any) => {
 			const { t } = this.props
 
@@ -2650,36 +2674,29 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 				if (!(sourceLayer && sourceLayer.clearKeyboardHotkey)) {
 					if (adlibPiece.isAction && adlibPiece.adlibAction) {
 						const action = adlibPiece.adlibAction
-						doUserAction(t, e, adlibPiece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB, (e) =>
-							MeteorCall.userAction.executeAction(e, this.props.playlist!._id, action.actionId, action.userData)
+						doUserAction(
+							t,
+							e,
+							adlibPiece.isGlobal ? UserAction.START_GLOBAL_ADLIB : UserAction.START_ADLIB,
+							(e) => MeteorCall.userAction.executeAction(e, this.props.playlist!._id, action.actionId, action.userData),
+							this.onPieceQueued
 						)
 					} else if (!adlibPiece.isGlobal && !adlibPiece.isAction) {
-						doUserAction(t, e, UserAction.START_ADLIB, (e) =>
-							MeteorCall.userAction.segmentAdLibPieceStart(
-								e,
-								this.props.playlist!._id,
-								currentPartInstanceId,
-								adlibPiece._id,
-								true
-							)
+						doUserAction(
+							t,
+							e,
+							UserAction.START_ADLIB,
+							(e) =>
+								MeteorCall.userAction.segmentAdLibPieceStart(
+									e,
+									this.props.playlist!._id,
+									currentPartInstanceId,
+									adlibPiece._id,
+									true
+								),
+							this.onPieceQueued
 						)
-					} else if (adlibPiece.isGlobal && !adlibPiece.isSticky) {
-						doUserAction(t, e, UserAction.START_GLOBAL_ADLIB, (e) =>
-							MeteorCall.userAction.baselineAdLibPieceStart(
-								e,
-								this.props.playlist!._id,
-								currentPartInstanceId,
-								adlibPiece._id,
-								true
-							)
-						)
-					} else if (adlibPiece.isSticky) {
-						// this.onToggleSticky(adlibPiece.sourceLayerId, e)
 					}
-				} else {
-					// if (sourceLayer && sourceLayer.clearKeyboardHotkey) {
-					// 	this.onClearAllSourceLayers([sourceLayer], e)
-					// }
 				}
 			}
 		}
@@ -2705,7 +2722,9 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			let pieceToQueue: AdLibPieceUi | undefined
 			let currentSegmentId: SegmentId | undefined
 			if (keyboardQueuedPiece) {
-				if (keyboardQueuedPiece.segmentId && uiSegmentMap.has(keyboardQueuedPiece.segmentId)) {
+				if (this.state.keyboardRequeue) {
+					pieceToQueue = keyboardQueuedPiece
+				} else if (keyboardQueuedPiece.segmentId && uiSegmentMap.has(keyboardQueuedPiece.segmentId)) {
 					const pieces = uiSegmentMap
 						.get(keyboardQueuedPiece.segmentId)!
 						.pieces.filter(this.isAdLibQueueableAndNonFloated)
@@ -2736,7 +2755,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 			}
 			if (pieceToQueue) {
 				this.queueAdLibPiece(pieceToQueue, e)
-				this.setState({ keyboardQueuedPiece: pieceToQueue })
+				this.setState({ keyboardQueuedPiece: pieceToQueue, keyboardRequeue: false })
 			}
 		}
 

--- a/meteor/lib/api/playout.ts
+++ b/meteor/lib/api/playout.ts
@@ -44,13 +44,13 @@ export interface NewPlayoutAPI {
 		partInstanceId: PartInstanceId,
 		pieceId: PieceId,
 		queue: boolean
-	): Promise<void>
+	): Promise<ClientAPI.ClientResponse<{ queuedPartInstanceId?: PartInstanceId }>>
 	rundownBaselineAdLibPieceStart(
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,
 		pieceId: PieceId,
 		queue: boolean
-	): Promise<void>
+	): Promise<ClientAPI.ClientResponse<{ queuedPartInstanceId?: PartInstanceId }>>
 	sourceLayerOnPartStop(
 		rundownPlaylistId: RundownPlaylistId,
 		partInstanceId: PartInstanceId,

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -87,7 +87,7 @@ export interface NewUserActionAPI extends MethodContext {
 		actionId: string,
 		userData: ActionUserData,
 		triggerMode?: string
-	): Promise<ClientAPI.ClientResponse<void>>
+	): Promise<ClientAPI.ClientResponse<{ queuedPartInstanceId?: PartInstanceId; taken?: boolean }>>
 	segmentAdLibPieceStart(
 		userEvent: string,
 		rundownPlaylistId: RundownPlaylistId,

--- a/meteor/server/api/blueprints/context/adlibActions.ts
+++ b/meteor/server/api/blueprints/context/adlibActions.ts
@@ -59,6 +59,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 	/** To be set by any mutation methods on this context. Indicates to core how extensive the changes are to the next partInstance */
 	public nextPartState: ActionPartChange = ActionPartChange.NONE
 	public takeAfterExecute: boolean
+	public queuedPartInstanceId: PartInstanceId | undefined = undefined
 
 	constructor(
 		cache: CacheForRundownPlaylist,
@@ -404,6 +405,7 @@ export class ActionExecutionContext extends ShowStyleContext implements IActionE
 		)
 
 		this.nextPartState = ActionPartChange.SAFE_CHANGE
+		this.queuedPartInstanceId = newPartInstance._id
 
 		return clone(unprotectObject(newPartInstance))
 	}

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -431,9 +431,7 @@ export function executeAction(
 	if (!playlist.currentPartInstanceId)
 		return ClientAPI.responseError(`No part is playing, please Take a part before executing an action.`)
 
-	return ClientAPI.responseSuccess(
-		ServerPlayoutAPI.executeAction(context, rundownPlaylistId, actionId, userData, triggerMode)
-	)
+	return ServerPlayoutAPI.executeAction(context, rundownPlaylistId, actionId, userData, triggerMode)
 }
 export function segmentAdLibPieceStart(
 	context: MethodContext,


### PR DESCRIPTION
- Tweaks styling: backgrounds and margins
- Fixes UI freezing on Takes, which was caused by tracker reruns on `SegmentTimelineContainer` due to the way Mini Shelf filter changes were detected
- Fixes Mini Shelf behavior: when a mini shelf adlib is queued from keyboard, but it's discarded (a part is set as next or a non-minishelf adlib is queued), it will be queued again when using the shortcuts, instead of advancing by one