### PR TITLE
Feat: take from standalone shelf

### DIFF
--- a/meteor/client/styles/shelf/externalFramePanel.scss
+++ b/meteor/client/styles/shelf/externalFramePanel.scss
@@ -10,6 +10,15 @@
 		border: none;
 		transform-origin: top left;
 	}
+	.external-frame-panel__overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		border: none;
+		transform-origin: top left;
+	}
 }
 
 .dashboard {

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2998,6 +2998,11 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 								<NoraPreviewRenderer />
 							</ErrorBoundary>
 							<ErrorBoundary>
+								{this.state.studioMode && !Settings.disableBlurBorderInShelf && (
+									<KeyboardFocusIndicator>
+										<div className="rundown-view__focus-lost-frame"></div>
+									</KeyboardFocusIndicator>
+								)}
 								<div onContextMenu={this.onContextMenuTop}>
 									<Shelf
 										buckets={this.props.buckets}

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -453,12 +453,6 @@ const RundownHeader = withTranslation()(
 			const { t } = props
 			if (this.props.studioMode) {
 				this.bindKeys = [
-					{
-						key: RundownViewKbdShortcuts.RUNDOWN_TAKE,
-						up: this.keyTake,
-						label: t('Take'),
-						global: true,
-					},
 					/*{
 						key: RundownViewKbdShortcuts.RUNDOWN_HOLD,
 						up: this.keyHold,
@@ -651,9 +645,6 @@ const RundownHeader = withTranslation()(
 					mousetrapHelper.unbind(k.key, 'RundownHeader', 'keydown')
 				}
 			})
-		}
-		keyTake = (e: mousetrap.ExtendedKeyboardEvent) => {
-			if (!isModalShowing()) this.take(e)
 		}
 		keyHold = (e: mousetrap.ExtendedKeyboardEvent) => {
 			this.hold(e)

--- a/meteor/client/ui/Settings/components/FilterEditor.tsx
+++ b/meteor/client/ui/Settings/components/FilterEditor.tsx
@@ -370,7 +370,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 			isRundownLayout: boolean,
 			isDashboardLayout: boolean
 		) {
-			const { float, text } = this.basicFields(item, tab, index)
+			const { float, text, checkbox } = this.basicFields(item, tab, index)
 			return (
 				<React.Fragment>
 					{text('name', 'Name')}
@@ -383,6 +383,7 @@ export default translateWithTracker<IProps, IState, ITrackedProps>((props: IProp
 						float('rank', 'Display Rank'),
 					]}
 					{float('scale', 'Scale')}
+					{checkbox('disableFocus', 'Disable focus')}
 				</React.Fragment>
 			)
 		}

--- a/meteor/client/ui/Shelf/ExternalFramePanel.tsx
+++ b/meteor/client/ui/Shelf/ExternalFramePanel.tsx
@@ -511,6 +511,11 @@ export const ExternalFramePanel = withTranslation()(
 
 		render() {
 			const scale = this.props.panel.scale || 1
+			const frameStyle = {
+				transform: `scale(${scale})`,
+				width: `calc(100% / ${scale})`,
+				height: `calc(100% / ${scale})`,
+			}
 			return (
 				<div
 					className="external-frame-panel"
@@ -527,11 +532,8 @@ export const ExternalFramePanel = withTranslation()(
 						className="external-frame-panel__iframe"
 						src={this.props.panel.url}
 						sandbox="allow-forms allow-popups allow-scripts allow-same-origin"
-						style={{
-							transform: `scale(${scale})`,
-							width: `calc(100% / ${scale})`,
-							height: `calc(100% / ${scale})`,
-						}}></iframe>
+						style={frameStyle}></iframe>
+					{this.props.panel.disableFocus && <div className="external-frame-panel__overlay" style={frameStyle}></div>}
 				</div>
 			)
 		}

--- a/meteor/client/ui/Shelf/Shelf.tsx
+++ b/meteor/client/ui/Shelf/Shelf.tsx
@@ -32,6 +32,9 @@ import { Studio } from '../../../lib/collections/Studios'
 import RundownViewEventBus, { RundownViewEvents, SelectPieceEvent } from '../RundownView/RundownViewEventBus'
 import { IAdLibListItem } from './AdLibListItem'
 import ShelfContextMenu from './ShelfContextMenu'
+import { isModalShowing } from '../../lib/ModalDialog'
+import { doUserAction, UserAction } from '../../lib/userAction'
+import { MeteorCall } from '../../../lib/api/methods'
 
 export enum ShelfTabs {
 	ADLIB = 'adlib',
@@ -135,6 +138,12 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 
 		this.bindKeys = [
 			{
+				key: RundownViewKbdShortcuts.RUNDOWN_TAKE,
+				up: this.keyTake,
+				label: t('Take'),
+				global: true,
+			},
+			{
 				key: RundownViewKbdShortcuts.RUNDOWN_TOGGLE_SHELF,
 				up: this.keyToggleShelf,
 				label: t('Toggle Shelf'),
@@ -146,6 +155,17 @@ export class ShelfBase extends React.Component<Translated<IShelfProps>, IState> 
 			// 	global: true
 			// }
 		]
+	}
+
+	keyTake = (e: mousetrap.ExtendedKeyboardEvent) => {
+		if (!isModalShowing()) this.take(e)
+	}
+
+	take = (e: any) => {
+		const { t } = this.props
+		if (this.props.studioMode) {
+			doUserAction(t, e, UserAction.TAKE, (e) => MeteorCall.userAction.take(e, this.props.playlist._id))
+		}
 	}
 
 	componentDidMount() {

--- a/meteor/lib/Settings.ts
+++ b/meteor/lib/Settings.ts
@@ -24,6 +24,8 @@ export interface ISettings {
 	autoExpandCurrentNextSegment: boolean
 	/** Disable blur border in RundownView */
 	disableBlurBorder: boolean
+	/** Disable blur border in the standalone Shelf */
+	disableBlurBorderInShelf: boolean
 	/** Default time scale zooming for the UI. Default: 1  */
 	defaultTimeScale: number
 	// Allow grabbing the entire timeline
@@ -57,6 +59,7 @@ const DEFAULT_SETTINGS: ISettings = {
 	autoExpandCurrentNextSegment: false,
 	autoRewindLeavingSegment: false,
 	disableBlurBorder: false,
+	disableBlurBorderInShelf: true,
 	defaultTimeScale: 1,
 	allowGrabbingTimeline: true,
 	enableUserAccounts: false,

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -55,6 +55,7 @@ export interface RundownLayoutExternalFrame extends RundownLayoutElementBase {
 	type: RundownLayoutElementType.EXTERNAL_FRAME
 	url: string
 	scale: number
+	disableFocus?: boolean
 }
 
 export enum RundownLayoutAdLibRegionRole {


### PR DESCRIPTION
Enable _Take_ keyboard shortcut in the standalone Shelf view.
Add _Disable focus_ option to the External Frame dashboard panel, that prevents the iframe from hijacking focus.
Adds optional keyboard blur indicator to the standalone Shelf view. Disabled by default; enable with `disableBlurBorderInShelf: false` setting.