### PR TITLE
Fix: Snapshot size

### DIFF
--- a/meteor/lib/api/shapshot.ts
+++ b/meteor/lib/api/shapshot.ts
@@ -4,7 +4,7 @@ import { RundownPlaylistId } from '../collections/RundownPlaylists'
 
 export interface NewSnapshotAPI {
 	storeSystemSnapshot(studioId: StudioId | null, reason: string): Promise<SnapshotId>
-	storeRundownPlaylist(playlistId: RundownPlaylistId, reason: string): Promise<SnapshotId>
+	storeRundownPlaylist(playlistId: RundownPlaylistId, reason: string, full?: boolean): Promise<SnapshotId>
 	storeDebugSnapshot(studioId: StudioId, reason: string): Promise<SnapshotId>
 	restoreSnapshot(snapshotId: SnapshotId): Promise<void>
 	removeSnapshot(snapshotId: SnapshotId): Promise<void>

--- a/meteor/lib/api/userActions.ts
+++ b/meteor/lib/api/userActions.ts
@@ -136,7 +136,8 @@ export interface NewUserActionAPI extends MethodContext {
 	storeRundownSnapshot(
 		userEvent: string,
 		playlistId: RundownPlaylistId,
-		reason: string
+		reason: string,
+		full?: boolean
 	): Promise<ClientAPI.ClientResponse<SnapshotId>>
 	removeRundownPlaylist(userEvent: string, playlistId: RundownPlaylistId): Promise<ClientAPI.ClientResponse<void>>
 	resyncRundownPlaylist(

--- a/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
@@ -22,6 +22,7 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
+    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -44,6 +45,7 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
+    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -96,6 +98,7 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
+    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -118,6 +121,7 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
+    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -57,16 +57,21 @@ export function resetRundown(cache: CacheForRundownPlaylist, rundown: Rundown) {
 			},
 		}
 	)
-	cache.PieceInstances.update(
-		{
-			rundownId: rundown._id,
-		},
-		{
-			$set: {
-				reset: true,
+	cache.deferAfterSave(() => {
+		PieceInstances.update(
+			{
+				rundownId: rundown._id,
 			},
-		}
-	)
+			{
+				$set: {
+					reset: true,
+				},
+			},
+			{
+				multi: true,
+			}
+		)
+	})
 }
 
 /**
@@ -103,18 +108,23 @@ export function resetRundownPlaylist(cache: CacheForRundownPlaylist, rundownPlay
 			},
 		}
 	)
-	cache.PieceInstances.update(
-		{
-			rundownId: {
-				$in: rundownIDs,
+	cache.deferAfterSave(() => {
+		PieceInstances.update(
+			{
+				rundownId: {
+					$in: rundownIDs,
+				},
 			},
-		},
-		{
-			$set: {
-				reset: true,
+			{
+				$set: {
+					reset: true,
+				},
 			},
-		}
-	)
+			{
+				multi: true,
+			}
+		)
+	})
 
 	cache.Parts.remove({
 		rundownId: {

--- a/meteor/server/api/userActions.ts
+++ b/meteor/server/api/userActions.ts
@@ -549,8 +549,13 @@ export function activateHold(
 export function userSaveEvaluation(context: MethodContext, evaluation: EvaluationBase): ClientAPI.ClientResponse<void> {
 	return ClientAPI.responseSuccess(saveEvaluation(context, evaluation))
 }
-export function userStoreRundownSnapshot(context: MethodContext, playlistId: RundownPlaylistId, reason: string) {
-	return ClientAPI.responseSuccess(storeRundownPlaylistSnapshot(context, playlistId, reason))
+export function userStoreRundownSnapshot(
+	context: MethodContext,
+	playlistId: RundownPlaylistId,
+	reason: string,
+	full?: boolean
+) {
+	return ClientAPI.responseSuccess(storeRundownPlaylistSnapshot(context, playlistId, reason, full))
 }
 export function removeRundownPlaylist(context: MethodContext, playlistId: RundownPlaylistId) {
 	let playlist = checkAccessAndGetPlaylist(context, playlistId)
@@ -1007,7 +1012,7 @@ class ServerUserActionAPI extends MethodContextAPI implements NewUserActionAPI {
 	saveEvaluation(_userEvent: string, evaluation: EvaluationBase) {
 		return makePromise(() => userSaveEvaluation(this, evaluation))
 	}
-	storeRundownSnapshot(_userEvent: string, playlistId: RundownPlaylistId, reason: string) {
+	storeRundownSnapshot(_userEvent: string, playlistId: RundownPlaylistId, reason: string, full?: boolean) {
 		return traceAction(
 			UserActionAPIMethods.storeRundownSnapshot,
 			userStoreRundownSnapshot,


### PR DESCRIPTION
By default limit PartInstances and PieceInstances in rundown snapshot to only non-reset, or reset but no older than 24 hours;
Adds extra parameter to the method and the REST endpoint to get the full snapshot with older instances