### PR TITLE
fix: activation resetting current pieceInstances

### DIFF
--- a/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
+++ b/meteor/server/api/playout/__tests__/__snapshots__/api.test.ts.snap
@@ -22,7 +22,6 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
-    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -45,7 +44,6 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
-    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -98,7 +96,6 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
-    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {
@@ -121,7 +118,6 @@ Array [
       "startSegmentId": "randomId9002_segment0",
       "status": 0,
     },
-    "reset": true,
     "rundownId": "randomId9002",
   },
   Object {

--- a/meteor/server/api/playout/lib.ts
+++ b/meteor/server/api/playout/lib.ts
@@ -57,10 +57,12 @@ export function resetRundown(cache: CacheForRundownPlaylist, rundown: Rundown) {
 			},
 		}
 	)
+	const partInstanceIds = cache.PartInstances.findFetch({ rundownId: rundown._id }).map((r) => r._id)
 	cache.deferAfterSave(() => {
 		PieceInstances.update(
 			{
 				rundownId: rundown._id,
+				partInstanceId: { $in: partInstanceIds },
 			},
 			{
 				$set: {
@@ -108,11 +110,15 @@ export function resetRundownPlaylist(cache: CacheForRundownPlaylist, rundownPlay
 			},
 		}
 	)
+	const partInstanceIds = cache.PartInstances.findFetch({ rundownId: { $in: rundownIDs } }).map((r) => r._id)
 	cache.deferAfterSave(() => {
 		PieceInstances.update(
 			{
 				rundownId: {
 					$in: rundownIDs,
+				},
+				partInstanceId: {
+					$in: partInstanceIds,
 				},
 			},
 			{


### PR DESCRIPTION
An update on PieceInstances with too broad selector was deferred after new pieceInstances may have been created (eg. when activating a playlist, when `resetRundownPlaylist` is called first), leading to displaying a Part with no Pieces.
Solution: make it reset only pieceInstances from partInstances existing at the time of execution

_Trust the snapshots next time_