### PR TITLE
feat: add static segment duration option

### DIFF
--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2265,8 +2265,6 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		}
 
 		renderSegments() {
-			const { t } = this.props
-
 			if (this.props.matchedSegments) {
 				let globalIndex = 0
 				const rundowns = this.props.matchedSegments.map((m) => m.rundown._id)
@@ -2336,6 +2334,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 													countdownToSegmentRequireLayers={
 														this.state.rundownViewLayout?.countdownToSegmentRequireLayers
 													}
+													staticSegmentDuration={this.state.rundownViewLayout?.staticSegmentDuration}
 												/>
 											</VirtualElement>
 										</ErrorBoundary>

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2265,6 +2265,8 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 		}
 
 		renderSegments() {
+			const { t } = this.props
+
 			if (this.props.matchedSegments) {
 				let globalIndex = 0
 				const rundowns = this.props.matchedSegments.map((m) => m.rundown._id)

--- a/meteor/client/ui/RundownView.tsx
+++ b/meteor/client/ui/RundownView.tsx
@@ -2334,7 +2334,7 @@ export const RundownView = translateWithTracker<IProps, IState, ITrackedProps>((
 													countdownToSegmentRequireLayers={
 														this.state.rundownViewLayout?.countdownToSegmentRequireLayers
 													}
-													staticSegmentDuration={this.state.rundownViewLayout?.staticSegmentDuration}
+													fixedSegmentDuration={this.state.rundownViewLayout?.fixedSegmentDuration}
 												/>
 											</VirtualElement>
 										</ErrorBoundary>

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -9,6 +9,8 @@ interface ISegmentDurationProps {
 	label?: ReactNode
 	/** If set, the timer will display just the played out duration */
 	countUp?: boolean
+	/** Always show planned segment duration instead of counting up/down */
+	static?: boolean
 }
 
 /**
@@ -32,17 +34,18 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 
 		const duration = budget - playedOut
 
-		return props.countUp ? (
+		return (
 			<>
 				{props.label}
-				<span>{RundownUtils.formatDiffToTimecode(playedOut, false, false, true, false, true, '+')}</span>
-			</>
-		) : (
-			<>
-				{props.label}
-				<span className={duration < 0 ? 'negative' : undefined}>
-					{RundownUtils.formatDiffToTimecode(duration, false, false, true, false, true, '+')}
-				</span>
+				{props.static ? (
+					<span>{RundownUtils.formatDiffToTimecode(budget, false, false, true, false, true, '+')}</span>
+				) : props.countUp ? (
+					<span>{RundownUtils.formatDiffToTimecode(playedOut, false, false, true, false, true, '+')}</span>
+				) : (
+					<span className={duration < 0 ? 'negative' : undefined}>
+						{RundownUtils.formatDiffToTimecode(duration, false, false, true, false, true, '+')}
+					</span>
+				)}
 			</>
 		)
 	}

--- a/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/meteor/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -10,7 +10,7 @@ interface ISegmentDurationProps {
 	/** If set, the timer will display just the played out duration */
 	countUp?: boolean
 	/** Always show planned segment duration instead of counting up/down */
-	static?: boolean
+	fixed?: boolean
 }
 
 /**
@@ -37,7 +37,7 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 		return (
 			<>
 				{props.label}
-				{props.static ? (
+				{props.fixed ? (
 					<span>{RundownUtils.formatDiffToTimecode(budget, false, false, true, false, true, '+')}</span>
 				) : props.countUp ? (
 					<span>{RundownUtils.formatDiffToTimecode(playedOut, false, false, true, false, true, '+')}</span>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -81,7 +81,7 @@ interface IProps {
 	isLastSegment: boolean
 	lastValidPartIndex: number | undefined
 	showCountdownToSegment: boolean
-	staticSegmentDuration: boolean | undefined
+	fixedSegmentDuration: boolean | undefined
 }
 interface IStateHeader {
 	timelineWidth: number
@@ -1026,7 +1026,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							<SegmentDuration
 								parts={this.props.parts}
 								label={<span className="segment-timeline__duration__label">{t('Duration')}</span>}
-								static={this.props.staticSegmentDuration}
+								fixed={this.props.fixedSegmentDuration}
 							/>
 						)}
 				</div>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -81,6 +81,7 @@ interface IProps {
 	isLastSegment: boolean
 	lastValidPartIndex: number | undefined
 	showCountdownToSegment: boolean
+	staticSegmentDuration: boolean | undefined
 }
 interface IStateHeader {
 	timelineWidth: number
@@ -1025,6 +1026,7 @@ export class SegmentTimelineClass extends React.Component<Translated<IProps>, IS
 							<SegmentDuration
 								parts={this.props.parts}
 								label={<span className="segment-timeline__duration__label">{t('Duration')}</span>}
+								static={this.props.staticSegmentDuration}
 							/>
 						)}
 				</div>

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -115,7 +115,7 @@ interface IProps {
 	ownNextPartInstance: PartInstance | undefined
 	rundownViewLayout: RundownViewLayout | undefined
 	countdownToSegmentRequireLayers: string[] | undefined
-	staticSegmentDuration: boolean | undefined
+	fixedSegmentDuration: boolean | undefined
 }
 interface IState {
 	scrollLeft: number
@@ -964,7 +964,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 						lastValidPartIndex={this.props.lastValidPartIndex}
 						onHeaderNoteClick={this.props.onHeaderNoteClick}
 						showCountdownToSegment={this.props.showCountdownToSegment}
-						staticSegmentDuration={this.props.staticSegmentDuration}
+						fixedSegmentDuration={this.props.fixedSegmentDuration}
 					/>
 				)) ||
 				null

--- a/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
+++ b/meteor/client/ui/SegmentTimeline/SegmentTimelineContainer.tsx
@@ -115,6 +115,7 @@ interface IProps {
 	ownNextPartInstance: PartInstance | undefined
 	rundownViewLayout: RundownViewLayout | undefined
 	countdownToSegmentRequireLayers: string[] | undefined
+	staticSegmentDuration: boolean | undefined
 }
 interface IState {
 	scrollLeft: number
@@ -963,6 +964,7 @@ export const SegmentTimelineContainer = translateWithTracker<IProps, IState, ITr
 						lastValidPartIndex={this.props.lastValidPartIndex}
 						onHeaderNoteClick={this.props.onHeaderNoteClick}
 						showCountdownToSegment={this.props.showCountdownToSegment}
+						staticSegmentDuration={this.props.staticSegmentDuration}
 					/>
 				)) ||
 				null

--- a/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
@@ -215,10 +215,10 @@ export default withTranslation()(
 					</div>
 					<div className="mod mvs mhs">
 						<label className="field">
-							{t('Static duration in Segment header')}
+							{t('Fixed duration in Segment header')}
 							<EditAttribute
 								modifiedClassName="bghl"
-								attribute={'staticSegmentDuration'}
+								attribute={'fixedSegmentDuration'}
 								obj={this.props.item}
 								type="checkbox"
 								collection={RundownLayouts}

--- a/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
+++ b/meteor/client/ui/Settings/components/rundownLayouts/RundownViewLayoutSettings.tsx
@@ -213,6 +213,24 @@ export default withTranslation()(
 							{t('One of these sourcelayers must have a piece for the countdown to segment on-air to be show')}
 						</span>
 					</div>
+					<div className="mod mvs mhs">
+						<label className="field">
+							{t('Static duration in Segment header')}
+							<EditAttribute
+								modifiedClassName="bghl"
+								attribute={'staticSegmentDuration'}
+								obj={this.props.item}
+								type="checkbox"
+								collection={RundownLayouts}
+								className="mod mas"
+							></EditAttribute>
+							<span className="text-s dimmed">
+								{t(
+									'The segment duration in the segment header always displays the planned duration instead of acting as a counter'
+								)}
+							</span>
+						</label>
+					</div>
 				</React.Fragment>
 			)
 		}

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -335,7 +335,7 @@ export interface RundownViewLayout extends RundownLayoutBase {
 	/** Only count down to the segment if it contains pieces on these layers */
 	countdownToSegmentRequireLayers: string[]
 	/** Always show planned segment duration instead of counting up/down when the segment is live */
-	staticSegmentDuration: boolean
+	fixedSegmentDuration: boolean
 }
 
 export interface RundownLayoutShelfBase extends RundownLayoutWithFilters {

--- a/meteor/lib/collections/RundownLayouts.ts
+++ b/meteor/lib/collections/RundownLayouts.ts
@@ -334,6 +334,8 @@ export interface RundownViewLayout extends RundownLayoutBase {
 	showBreaksAsSegments: boolean
 	/** Only count down to the segment if it contains pieces on these layers */
 	countdownToSegmentRequireLayers: string[]
+	/** Always show planned segment duration instead of counting up/down when the segment is live */
+	staticSegmentDuration: boolean
 }
 
 export interface RundownLayoutShelfBase extends RundownLayoutWithFilters {


### PR DESCRIPTION
Adds _Static duration in Segment header_ option to Rundown View Layout. When enabled, it makes the segment duration in the segment header always show the planned duration instead of acting as a counter when the segment becomes live.
